### PR TITLE
added note on how to import static site content into the Docker volumes

### DIFF
--- a/content/running_bookwyrm/install-prod.md
+++ b/content/running_bookwyrm/install-prod.md
@@ -48,6 +48,7 @@ Instructions for running BookWyrm in production:
 - If you wish to use an external storage for static assets and media files (such as an S3-compatible service), [follow the instructions](/external-storage.html) until it tells you to come back here
 - Run docker-compose in the background with: `docker-compose up -d`
 - Initialize the database with: `./bw-dev initdb`
+- Import static content into Docker volumes with: `./bw-dev collectstatic`
 
 Congrats! You did it, go to your domain and enjoy the fruits of your labors.
 


### PR DESCRIPTION
With the normal installation instructions the site remains somewhat broken when using the docker containers as the static images will not be copied into the Docker Volumes created by docker-compose. There is already a command in the bw-dev utility which will copy static content. This can just be executed after the initdb command and will populate the static content into the Docker volumes.