### PR TITLE
Updates external storage documentation, adds new sync_media_to_s3 command

### DIFF
--- a/content/running_bookwyrm/cli.md
+++ b/content/running_bookwyrm/cli.md
@@ -102,7 +102,11 @@ See [External Storage](/external-storage.html) for more information.
 
 ### copy_media_to_s3
 
-Migrate uploaded media from an existing Bookwrym installation to an S3-compatible "bucket".
+Migrate all uploaded media from an existing Bookwrym installation to an S3-compatible "bucket". Use for initial upload to an empty bucket.
+
+### sync_media_to_s3
+
+Sync new or changed uploaded media from an existing Bookwrym installation to an S3-compatible "bucket". Use to ensure all local files are uploaded to an existing bucket.
 
 ### set_cors_to_s3 filename
 

--- a/content/running_bookwyrm/external-storage.md
+++ b/content/running_bookwyrm/external-storage.md
@@ -138,6 +138,8 @@ To ensure that any remaining files are uploaded to external storage after switch
 
 ### Updating the instance connector
 
+*Note: You can skip this step if you're running an updated version of BookWyrm; in September 2021 the "self connector" was removed in [PR #1413](https://github.com/bookwyrm-social/bookwyrm/pull/1413)*
+
 In order for the right URL to be used when displaying local book search results, we have to modify the value for the cover images URL base.
 
 Connector data can be accessed through the Django admin interface, located at the url `http://MY_DOMAIN_NAME/admin`. The connector for your own instance is the first record in the database, so you can access the connector with this URL: `https://MY_DOMAIN_NAME/admin/bookwyrm/connector/1/change/`.

--- a/content/running_bookwyrm/external-storage.md
+++ b/content/running_bookwyrm/external-storage.md
@@ -45,7 +45,7 @@ If your S3-compatible service is Amazon AWS, you should be set. If not, you’ll
 
 ### Copying local media to external storage
 
-If your BookWyrm instance is already running, and media have been uploaded (user avatars, book covers…), you will need to migrate uploaded media to your bucket.
+If your BookWyrm instance is already running and media have been uploaded (user avatars, book covers…), you will need to migrate uploaded media to your bucket.
 
 This task is done with the command: 
 
@@ -59,6 +59,12 @@ To enable the S3-compatible external storage, you will have to edit your `.env` 
 
 ```
 USE_S3=true
+```
+
+If your external storage is being served over HTTPS (which most are these days), you'll also need to make sure that `USE_HTTPS` is set to `true`, so images will be loaded over HTTPS:
+
+```
+USE_HTTPS=true
 ```
 
 #### Static assets
@@ -107,10 +113,10 @@ If you are starting a new BookWyrm instance, you can go back to the setup instru
 
 ### Restarting your instance
 
-Once the media migration has been done and the static assets are collected, you can restart your instance with:
+Once the media migration has been done and the static assets are collected, you can load the new `.env` configuration and restart your instance with:
 
 ```bash
-docker compose restart
+./bw-dev up -d
 ```
 
 If all goes well, your storage has been changed without server downtime. If some fonts are missing (and your browser’s JS console lights up with alerts about CORS), something went wrong [here](#cors-settings). In that case it might be good to check the headers of a HTTP request against a file on your bucket:

--- a/content/running_bookwyrm/external-storage.md
+++ b/content/running_bookwyrm/external-storage.md
@@ -129,6 +129,13 @@ Replace `MY_DOMAIN_NAME` with your instance domain name, `BUCKET_URL` with the U
 
 If you see any message, especially a message starting with `<Error><Code>CORSForbidden</Code>`, it didn’t work. If you see no message, it worked.
 
+For an active instance, there may be a handful of files that were created locally during the time between migrating the files to external storage, and restarting the app so it uses the external storage.
+To ensure that any remaining files are uploaded to external storage after switching over, you can use the following command, which will upload only files that aren't already present in the external storage:
+
+```bash
+./bw-dev sync_media_to_s3
+```
+
 ### Updating the instance connector
 
 In order for the right URL to be used when displaying local book search results, we have to modify the value for the cover images URL base.


### PR DESCRIPTION
This documents the new command added in https://github.com/bookwyrm-social/bookwyrm/pull/1686, and also adds a couple tips gleaned from my recent setup of external storage: namely, make sure `USE_HTTPS` is set, and you don't have to do the last step any more.