### PR TITLE
Uses ./bw-dev consistently, adds `collectstatic` step

### DIFF
--- a/content/contributing/install-dev.md
+++ b/content/contributing/install-dev.md
@@ -27,7 +27,7 @@ cp nginx/development nginx/default.conf
 ```
 :::shell linenums=False
 ./bw-dev build            # Build the docker images
-./bw-dev initdb           # Initialize and run migrations for the database
+./bw-dev initdb           # Initialize the database and run migrations
 ./bw-dev collectstatic    # Copy static files into the docker containers
 ./bw-dev up               # Start the docker containers
 ```

--- a/content/contributing/install-dev.md
+++ b/content/contributing/install-dev.md
@@ -26,12 +26,14 @@ cp nginx/development nginx/default.conf
 - Start the application. In the command line, run:
 ```
 :::shell linenums=False
-docker-compose build
-docker-compose run --rm web python manage.py migrate
-docker-compose run --rm web python manage.py initdb
-docker-compose up
+./bw-dev build            # Build the docker images
+./bw-dev initdb           # Initialize and run migrations for the database
+./bw-dev collectstatic    # Copy static files into the docker containers
+./bw-dev up               # Start the docker containers
 ```
 - Once the build is complete, you can access the instance at `http://localhost:1333`
+
+If you're curious: the `./bw-dev` command is a simple shell script runs various other tools: above, you could skip it and run `docker-compose build` or `docker-compose up` directly if you like. `./bw-dev` just collects them into one common place for convenience. Run it without arguments to get a list of available commands, or open it up and look around to see exactly what each command is doing!
 
 ### Editing or creating Models
 
@@ -44,7 +46,7 @@ If you change or create a model, you will probably change the database structure
 ```
 
 ### Editing static files
-If you edit the CSS or JavaScript, you will need to run Django's `collectstatic` command in order for your changes to have effect. You can do this by running:
+Any time you edit the CSS or JavaScript, you will need to run Django's `collectstatic` command again in order for your changes to have effect:
 ```
 :::shell linenums=False
 ./bw-dev collectstatic

--- a/content/running_bookwyrm/updating.md
+++ b/content/running_bookwyrm/updating.md
@@ -16,10 +16,12 @@ Feeds for each user are stored in Redis. To re-populate a stream, use the manage
 
 ```
 :::bash linenums=False
+./bw-dev populate_streams
+# Or use docker-compose directly
 docker-compose run --rm web python manage.py populate_streams
 ```
 
-If something has gone terribly awry, the stream data can be deleted. 
+If something has gone terribly awry, the stream data can be deleted.
 
 ```
 :::bash linenums=False


### PR DESCRIPTION
Also add a little explainer about what `./bw-dev` does so it's not some mysterious opaque command.

This addresses the main issue in https://github.com/bookwyrm-social/bookwyrm/issues/1665