### PR TITLE
Fix copyediting in gender-neutral language section

### DIFF
--- a/content/contributing/translation.md
+++ b/content/contributing/translation.md
@@ -8,7 +8,7 @@ You can join the BookWyrm translation project at [translate.joinbookwyrm.com](ht
 
 ## Gender-neutral language
 
-Wherever possible, BookWyrm translations should use gender-neutral language, even when the default for a language to default to male as a neutral gender or use something similar to "he/she." It's also important for translations to be clear, concise, and legible to a screen reader, and sometimes these goals are in conflict; there isn't a perfect, one-size-fits all answer, and the solution depends on the language.
+Wherever possible, BookWyrm translations should use gender-neutral language. This applies even if a language defaults to male as a neutral gender, or if it uses something similar to "he/she". It's also important for translations to be clear, concise, and legible to a screen reader, and sometimes these goals are in conflict; there isn't a perfect, one-size-fits all answer, and the solution depends on the language.
 
 As a guiding principal, try to place a higher value on inclusive and gender-neutral language than on formal correctness or officially approved style guides. In English, for example, many formal style guides require a singular "she" or "he" pronoun to be used when referring to an individual, but it would be better in BookWyrm to use the gender-neutral singular "they" instead.
 


### PR DESCRIPTION
There was a missing or duplicate word here I think ("even when the default for a language to default to male"), but I tried to reword it a little more to be clearer while I was at it. It's a tough sentence to communicate well. I scanned the original quickly and initially thought it was _recommending_ "he/she" and was confused, so I tried to be a little more explicit. Long compound phrases like this are just hard to make clear, I think!

P.S. Love this section btw!! It is good and well thought out.