### PR TITLE
Add initdb and fix chown command

### DIFF
--- a/content/running_bookwyrm/install-prod-dockerless.md
+++ b/content/running_bookwyrm/install-prod-dockerless.md
@@ -74,14 +74,15 @@ GRANT ALL PRIVILEGES ON DATABASE bookwyrm TO bookwyrm;
 \q
 ```
     
-- Initialize the database by running `venv/bin/python3 manage.py migrate`
+- Migrate the database schema by running `venv/bin/python3 manage.py migrate`
+- Initialize the database by running `venv/bin/python3 manage.py initdb`
 - Create the static by running `venv/bin/python3 manage.py collectstatic --no-input`
 - If you wish to use an external storage for static assets and media files (such as an S3-compatible service), [follow the instructions](/external-storage.html) until it tells you to come back here
 - Create and setup your `bookwyrm` user
     - Make the system bookwyrm user:
         `useradd bookwyrm -r`
     - Change the owner of your install directory to bookwyrm:
-        `chown -R /opt/bookwyrm bookwyrm:bookwyrm`
+        `chown -R bookwyrm:bookwyrm /opt/bookwyrm`
     - You should now run bookwyrm related commands as the bookwyrm user:
         `sudo -u bookwyrm echo I am the $(whoami) user`
 

--- a/locale/fr_FR/content/running_bookwyrm/install-prod-dockerless.md
+++ b/locale/fr_FR/content/running_bookwyrm/install-prod-dockerless.md
@@ -65,12 +65,13 @@ GRANT ALL PRIVILEGES ON DATABASE bookwyrm TO bookwyrm;
 \q
 ```
 
-- Initialisez la base de données en exécutant `venv/bin/python3 manage.py migrate`
+- Migrer le schema de la base de données en exécutant `venv/bin/python3 manage.py migrate`
+- Initialisez la base de données en exécutant `venv/bin/python3 manage.py initdb`
 - Générez les static en exécutant `venv/bin/python3 manage.py collectstatic --no-input`
 - Si vous souhaitez utiliser un stockage externe pour les ressources statiques et les fichiers multimédias (comme un service compatible S3), [suivez les instructions](/external-storage.html) jusqu'à être redirigé ici
 - Créez et configurez votre utilisateur `bookwyrm`
     - Créez l'utilisateur système bookwyrm: `useradd bookwyrm -r`
-    - Changez le propriétaire de votre répertoire d'installation en bookwyrm&nbsp;: `chown -R /opt/bookwyrm bookwyrm:bookwyrm`
+    - Changez le propriétaire de votre répertoire d'installation en bookwyrm&nbsp;: `chown -R bookwyrm:bookwyrm /opt/bookwyrm`
     - Vous devriez maintenant exécuter les commandes liées à bookwyrm avec l'utilisateur de bookwyrm : `sudo -u bookwyrm echo I am the $(whoami) user`
 
 - Générez le code administrateur avec `sudo -u bookwyrm venv/bin/python3 manage.py admin_code`, et copiez le pour l'utiliser lors de la création du compte administrateur.


### PR DESCRIPTION
# Goal

- Add the `initdb` command after the `migrate` one, according to https://github.com/bookwyrm-social/bookwyrm/issues/2347
- Fix the `chown` command order

# Information

I also provide the french translation for this change.