### PR TITLE
Adjusting docker-compose commands

### DIFF
--- a/content/running_bookwyrm/updating.md
+++ b/content/running_bookwyrm/updating.md
@@ -1,6 +1,6 @@
 ---
 Title: Updating Your Instance
-Date: 2021-04-13
+Date: 2022-11-17
 Order: 3
 ---
 
@@ -8,9 +8,9 @@ When there are changes available in the production branch, you can install and g
 
 - `git pull` gets the updated code from the git repository. If there are conflicts, you may need to run `git pull` separately and resolve the conflicts before trying the `./bw-dev update` script again.
 - `docker-compose build` rebuilds the images, which ensures that the correct packages are installed. This step takes a long time and is only needed when the dependencies (including pip `requirements.txt` packages) have changed, so you can comment it out if you want a quicker update path and don't mind un-commenting it as needed.
-- `docker-compose exec web python manage.py migrate` runs the database migrations in Django
-- `docker-compose exec web python manage.py collectstatic --no-input` loads any updated static files (such as the JavaScript and CSS)
-- `docker-compose restart` reloads the docker containers
+- `docker-compose run --rm web python manage.py migrate` runs the database migrations in Django using the newly built Docker images
+- `docker-compose run --rm web python manage.py collectstatic --no-input` loads any updated static files (such as the JavaScript and CSS)
+- `docker-compose down; docker-compose up -d` will restart all the docker containers and make use of the newly built images (Attention: downtime during the restart)
 
 ## Re-building activity streams
 


### PR DESCRIPTION
The previously described docker-compose commands would not work as they were using the existing containers with the old image instead of the newly built container images. Additionally a ```docker-compose restart``` would use the newly built images nor reflect possible changes in the docker-compose.yml