### PR TITLE
Add a link to the BookWyrm app code repo

### DIFF
--- a/content/running_bookwyrm/install-prod.md
+++ b/content/running_bookwyrm/install-prod.md
@@ -14,6 +14,8 @@ This project is still young and isn't, at the moment, very stable, so please pro
 
 ## Install and configure BookWyrm
 
+There are several repos in the BookWyrm org, including documentation, a static landing page, and the actual Bookwyrm code. To run BookWyrm, you want the actual app code which is in [bookwyrm-social/bookwyrm](https://github.com/bookwyrm-social/bookwyrm).
+
 The `production` branch of BookWyrm contains a number of tools not on the `main` branch that are suited for running in production, such as `docker-compose` changes to update the default commands or configuration of containers, and individual changes to container config to enable things like SSL or regular backups.
 
 Instructions for running BookWyrm in production:


### PR DESCRIPTION
I spent a good amount of time trying to follow the instructions to run my own Bookwyrm server, with the wrong code checked out. I had checked out join-bookwyrm, which didn't have a production branch or the correct code.
I'm not quite sure how I ended up there, but it was the first bookwyrm repo I landed on. I know I wanted to not justgcopy the instructions, but instead understand them. And of course, then I skimmed them, and used the bookwyrm repo I already had open.

I think this adds greater clarity so others don't run into the same trouble.