### PR TITLE
fix: typo in translations link

### DIFF
--- a/content/contributing/style_guide.md
+++ b/content/contributing/style_guide.md
@@ -18,7 +18,7 @@ Pull requests have to pass all the automated checks before they can be merged - 
 
 We use [EditorConfig](https://editorconfig.org) to maintain consistent indenting and line endings.
 
-### Python 
+### Python
 
 BookWyrm uses the [Black](https://github.com/psf/black) code formatter to keep the Python codebase consistent styled. All new pull requests are checked with GitHub actions, and you can automatically fix code style problems by running `./bw-dev black`
 
@@ -40,7 +40,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/locale/de_DE/content/contributing/style_guide.md
+++ b/locale/de_DE/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ Wir verwenden [stylelint](https://stylelint.io), um alle CSS-Regeln zu überprü
 
 Bookwyrm hat zum Ziel, so umfassend und zugänglich wie möglich zu sein.
 
-Überprüfen Sie die [Checkliste für inklusives Web Design](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) bevor du einen Pull-Reuqest erstellst. Für Barrierefreiheit ist [A11Y-101](https://www.a11y-101.com/development) ebenfalls eine nützliche Quelle. Weitere Informationen darüber, wie du deine Seitenvorlagen mehrsprachig erstellst, findest du im [Abschnitt Übersetzungen](/translations.html).
+Überprüfen Sie die [Checkliste für inklusives Web Design](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) bevor du einen Pull-Reuqest erstellst. Für Barrierefreiheit ist [A11Y-101](https://www.a11y-101.com/development) ebenfalls eine nützliche Quelle. Weitere Informationen darüber, wie du deine Seitenvorlagen mehrsprachig erstellst, findest du im [Abschnitt Übersetzungen](/translation.html).
 
 Einige besondere Dinge, die Bookwyrm-Beitragende für nützlich erachtet haben, sind:
 

--- a/locale/en_Oulipo/content/contributing/style_guide.md
+++ b/locale/en_Oulipo/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/locale/es_ES/content/contributing/style_guide.md
+++ b/locale/es_ES/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/locale/fi_FI/content/contributing/style_guide.md
+++ b/locale/fi_FI/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/locale/fr_FR/content/contributing/style_guide.md
+++ b/locale/fr_FR/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ Nous utilisons [stylelint](https://stylelint.io) pour vérifier toutes les règl
 
 BookWyrm aspire à être aussi inclusif et accessible que possible.
 
-Lorsque vous contribuez du code, vérifiez la [checklist Inclusive Web Design](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) avant de proposer votre pull request. Pour des conseils sur l'accessibilité, [A11Y-101](https://www.a11y-101.com/development) est également une ressource utile. Pour plus d'informations sur la manière de rendre vos gabarits de page multilingues, voir [la section Traductions](/translations.html).
+Lorsque vous contribuez du code, vérifiez la [checklist Inclusive Web Design](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) avant de proposer votre pull request. Pour des conseils sur l'accessibilité, [A11Y-101](https://www.a11y-101.com/development) est également une ressource utile. Pour plus d'informations sur la manière de rendre vos gabarits de page multilingues, voir [la section Traductions](/translation.html).
 
 Quelques particularités à garder en tête pour la contribution au code de BookWyrm :
 

--- a/locale/gl_ES/content/contributing/style_guide.md
+++ b/locale/gl_ES/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/locale/it_IT/content/contributing/style_guide.md
+++ b/locale/it_IT/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ Usiamo [stylelint](https://stylelint.io) per controllare tutte le regole CSS. Co
 
 Bookwyrm mira a essere il più completo e accessibile possibile.
 
-Quando si contribuisce con il codice, controllare la checklist [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) prima di archiviare la tua richiesta pull. Per la consulenza in materia di accessibilità, [A11Y-101](https://www.a11y-101.com/development) è anche una fonte utile. Per informazioni su come rendere i modelli di pagina multilingue, vedere la [sezione Traduzioni](/translations.html).
+Quando si contribuisce con il codice, controllare la checklist [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) prima di archiviare la tua richiesta pull. Per la consulenza in materia di accessibilità, [A11Y-101](https://www.a11y-101.com/development) è anche una fonte utile. Per informazioni su come rendere i modelli di pagina multilingue, vedere la [sezione Traduzioni](/translation.html).
 
 Alcune cose particolari che i contributori di Bookwyrm hanno trovato utili per ricordare sono:
 

--- a/locale/lt_LT/content/contributing/style_guide.md
+++ b/locale/lt_LT/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/locale/no_NO/content/contributing/style_guide.md
+++ b/locale/no_NO/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/locale/pl_PL/content/contributing/style_guide.md
+++ b/locale/pl_PL/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ Korzystamy z [stylelint](https://stylelint.io), do sprawdzania zasad CSS. Tak ja
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Niektórymi z aspektów, które współtwórcy BookWyrm uznali za przydatne do zapamiętania są:
 

--- a/locale/pt_BR/content/contributing/style_guide.md
+++ b/locale/pt_BR/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ Usamos o [stylelint](https://stylelint.io) para conferir todas as regras de CSS.
 
 A BookWyrm quer ser o mais inclusiva e acessível possível.
 
-Quando for contribuir com código, dê uma olhada na [Check list de web design inclusivo](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) antes de enviar o pull request. Para sugestões de acessibilidade, o [A11Y-101](https://www.a11y-101.com/development) também é uma fonte útil. Para saber como fazer seus templates serem compatíveis com vários idiomas, veja a [seção Traduções](/translations.html).
+Quando for contribuir com código, dê uma olhada na [Check list de web design inclusivo](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) antes de enviar o pull request. Para sugestões de acessibilidade, o [A11Y-101](https://www.a11y-101.com/development) também é uma fonte útil. Para saber como fazer seus templates serem compatíveis com vários idiomas, veja a [seção Traduções](/translation.html).
 
 Algumas coisas que colaboradores da BookWyrm acharam boas de se lembrar:
 

--- a/locale/pt_PT/content/contributing/style_guide.md
+++ b/locale/pt_PT/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/locale/ro_RO/content/contributing/style_guide.md
+++ b/locale/ro_RO/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ Folosim [stylelint](https://stylelint.io) pentru a verifica toate regulile CSS. 
 
 BookWyrm dorește să fie cât mai inclusiv și accesibil posibil.
 
-Când contribuiți la cod, verificați [lista Design Web Inclusiv](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) înainte de a depune cererea dvs. de extragere. Pentru sfaturi de accesibilitate, [A11Y-101](https://www.a11y-101.com/development) este de asemenea o resursă utilă. Pentru informații despre cum să faceți șablonul de pagină bilingv, consultați [secțiunea de Traduceri](/translations.html).
+Când contribuiți la cod, verificați [lista Design Web Inclusiv](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) înainte de a depune cererea dvs. de extragere. Pentru sfaturi de accesibilitate, [A11Y-101](https://www.a11y-101.com/development) este de asemenea o resursă utilă. Pentru informații despre cum să faceți șablonul de pagină bilingv, consultați [secțiunea de Traduceri](/translation.html).
 
 Câteva lucruri care li s-au părut contribuitorilor BookWyrm util de reținut sunt:
 

--- a/locale/sv_SE/content/contributing/style_guide.md
+++ b/locale/sv_SE/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/locale/zh_Hans/content/contributing/style_guide.md
+++ b/locale/zh_Hans/content/contributing/style_guide.md
@@ -38,7 +38,7 @@ We use [stylelint](https://stylelint.io) to check all CSS rules. As with Pylint 
 
 Bookwyrm aims to be as inclusive and accessible as possible.
 
-When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translations.html).
+When contributing code, check the [Inclusive Web Design Checklist](https://github.com/bookwyrm-social/bookwyrm/discussions/1354) before you file your pull request. For accessibility advice, [A11Y-101](https://www.a11y-101.com/development) is also a useful source. For information on how to make your page templates multi-lingual, see the [Translations section](/translation.html).
 
 Some particular things that Bookwyrm contributors have found useful to remember are:
 

--- a/site/de/style_guide.html
+++ b/site/de/style_guide.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
     <title>
-        
+
 Stilleitfaden
 
     </title>
@@ -56,19 +56,19 @@ Stilleitfaden
         <div class="navbar-item">
             <div class="select">
                 <select aria-label="Select a language" id="language_selection">
-                    
+
                     <option value="" >English (US)</option>
-                    
+
                     <option value="de/" selected>Deutsch</option>
-                    
+
                     <option value="fr/" >Français</option>
-                    
+
                     <option value="pl/" >Polski</option>
-                    
+
                     <option value="pt-br/" >Português do Brasil</option>
-                    
+
                     <option value="ro/" >Română</option>
-                    
+
               </select>
             </div>
         </div>
@@ -79,110 +79,110 @@ Stilleitfaden
 <section class="section">
 
     <header class="content block column is-offset-one-quarter pl-2">
-        
+
 <h1 class="title is-1">Stilleitfaden</h1>
 
     </header>
     <div class="columns">
 	<nav class="menu column is-one-quarter mt-2">
             <h2 class="menu-label"><a href="/de/">Welcome</a></h2>
-            
+
             <h2 class="menu-label">Using BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/de/posting-statuses.html" >Beitragsstatus</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/adding-books.html" >Bücher hinzufügen</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Running BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/de/install-prod.html" >Installation in Produktion</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/install-prod-dockerless.html" >Installation ohne Docker</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/updating.html" >Deine Instanz updaten</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/reverse-proxy.html" >Verwenden eines Reverse-Proxy</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/moderation.html" >Moderation</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/monitoring-queue.html" >Überwachungswarteschlange</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/external-storage.html" >Externer Speicher</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/optional_features.html" >Optionale Funktionen</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/cli.html" >Befehlszeilenwerkzeug</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Contributing</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/de/contributing.html" >Wie mitmachen</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/translation.html" >Übersetzungen</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/install-dev.html" >Entwicklungsumgebung</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/style_guide.html" class="is-active">Stilleitfaden</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/debug_toolbar.html" >Django Debug-Symbolleiste</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Codebase</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/de/activitypub.html" >ActivityPub</a>
                 </li>
-                
+
                 <li>
                     <a href="/de/permissions.html" >Berechtigungen</a>
                 </li>
-                
+
             </ul>
-            
+
         </nav>
 
         <div class="column">
-            
+
 <section class="block content">
     <h2>Pull Requests</h2>
 <p>Du möchstest also Code zu BookWyrm hinzufügen: Das ist klasse! Wenn es ein offenes Problem gibt, dass du beheben möchtest, ist es hilfreich, das Problem zu kommentieren, damit die Arbeit nicht dupliziert wird. Versuche den Umfang von Pull Requests kleinzuhalten und konzentriere dich auf ein einzelnes Thema. Auf diese Weise ist es einfacher zu überprüfen und wenn ein Teil Änderungen braucht, wird er die anderen Teile nicht aufhalten.</p>
@@ -202,7 +202,7 @@ Stilleitfaden
 <p><a href="https://eslint.org">ESLint</a> überprüft alle von Ihnen vorgenommenen JavaScript-Änderungen. Falls ESLint dein funktionierendes JavaScript nicht mag, überprüfe die Linter-Meldung auf das genaue Problem.</p>
 <h2>Inklusives Design</h2>
 <p>Bookwyrm hat zum Ziel, so umfassend und zugänglich wie möglich zu sein.</p>
-<p>Überprüfen Sie die <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">Checkliste für inklusives Web Design</a> bevor du einen Pull-Reuqest erstellst. Für Barrierefreiheit ist <a href="https://www.a11y-101.com/development">A11Y-101</a> ebenfalls eine nützliche Quelle. Weitere Informationen darüber, wie du deine Seitenvorlagen mehrsprachig erstellst, findest du im <a href="/translations.html">Abschnitt Übersetzungen</a>.</p>
+<p>Überprüfen Sie die <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">Checkliste für inklusives Web Design</a> bevor du einen Pull-Reuqest erstellst. Für Barrierefreiheit ist <a href="https://www.a11y-101.com/development">A11Y-101</a> ebenfalls eine nützliche Quelle. Weitere Informationen darüber, wie du deine Seitenvorlagen mehrsprachig erstellst, findest du im <a href="/translation.html">Abschnitt Übersetzungen</a>.</p>
 <p>Einige besondere Dinge, die Bookwyrm-Beitragende für nützlich erachtet haben, sind:</p>
 <h3>Formulare</h3>
 <ul>

--- a/site/fr/style_guide.html
+++ b/site/fr/style_guide.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
     <title>
-        
+
 Style Guide
 
     </title>
@@ -56,19 +56,19 @@ Style Guide
         <div class="navbar-item">
             <div class="select">
                 <select aria-label="Select a language" id="language_selection">
-                    
+
                     <option value="" >English (US)</option>
-                    
+
                     <option value="de/" >Deutsch</option>
-                    
+
                     <option value="fr/" selected>Français</option>
-                    
+
                     <option value="pl/" >Polski</option>
-                    
+
                     <option value="pt-br/" >Português do Brasil</option>
-                    
+
                     <option value="ro/" >Română</option>
-                    
+
               </select>
             </div>
         </div>
@@ -79,110 +79,110 @@ Style Guide
 <section class="section">
 
     <header class="content block column is-offset-one-quarter pl-2">
-        
+
 <h1 class="title is-1">Style Guide</h1>
 
     </header>
     <div class="columns">
 	<nav class="menu column is-one-quarter mt-2">
             <h2 class="menu-label"><a href="/fr/">Welcome</a></h2>
-            
+
             <h2 class="menu-label">Using BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/fr/posting-statuses.html" >Publication de statuts</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/adding-books.html" >Ajout de livres</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Running BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/fr/reverse-proxy.html" ></a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/moderation.html" >Modération</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/install-prod.html" >Installation en Production</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/install-prod-dockerless.html" >Installation sans Docker</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/updating.html" >Mise à jour de votre instance</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/monitoring-queue.html" >Suivi de la file d'attente</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/external-storage.html" >Stockage Externe</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/optional_features.html" >Fonctionnalités optionnelles</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/cli.html" >Outils en ligne de commande</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Contributing</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/fr/contributing.html" >Comment contribuer</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/translation.html" >Translations</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/install-dev.html" >Environnement de développement</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/style_guide.html" class="is-active">Style Guide</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/debug_toolbar.html" >Django Debug Toolbar</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Codebase</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/fr/activitypub.html" >ActivityPub</a>
                 </li>
-                
+
                 <li>
                     <a href="/fr/permissions.html" >Permissions</a>
                 </li>
-                
+
             </ul>
-            
+
         </nav>
 
         <div class="column">
-            
+
 <section class="block content">
     <h2>Pull requests</h2>
 <p>Vous voulez contribuer au code de BookWyrm, c’est génial ! S'il y a un problème ouvert que vous souhaitez corriger, il est préférable de laisser un commentaire dans la conversation pour que le travail ne soit pas dupliqué. Essayez de limiter la portée des pull requests et de concentrer votre attention sur un seul sujet. Comme ça elle est plus facile à relire, et si une partie a besoin de changements elle ne retardera pas les autres parties.</p>
@@ -202,7 +202,7 @@ Style Guide
 <p><a href="https://eslint.org">ESLint</a> vérifie toute modification effectuée en JavaScript. Si ESLint n'aime pas votre JavaScript (même fonctionnel), vérifiez le message linter pour le problème exact.</p>
 <h2>Design inclusif</h2>
 <p>BookWyrm aspire à être aussi inclusif et accessible que possible.</p>
-<p>Lorsque vous contribuez du code, vérifiez la <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">checklist Inclusive Web Design</a> avant de proposer votre pull request. Pour des conseils sur l'accessibilité, <a href="https://www.a11y-101.com/development">A11Y-101</a> est également une ressource utile. Pour plus d'informations sur la manière de rendre vos gabarits de page multilingues, voir <a href="/translations.html">la section Traductions</a>.</p>
+<p>Lorsque vous contribuez du code, vérifiez la <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">checklist Inclusive Web Design</a> avant de proposer votre pull request. Pour des conseils sur l'accessibilité, <a href="https://www.a11y-101.com/development">A11Y-101</a> est également une ressource utile. Pour plus d'informations sur la manière de rendre vos gabarits de page multilingues, voir <a href="/translation.html">la section Traductions</a>.</p>
 <p>Quelques particularités à garder en tête pour la contribution au code de BookWyrm :</p>
 <h3>Formulaires</h3>
 <ul>

--- a/site/pl/style_guide.html
+++ b/site/pl/style_guide.html
@@ -2,7 +2,7 @@
 <html lang="pl">
 <head>
     <title>
-        
+
 Style Guide
 
     </title>
@@ -56,19 +56,19 @@ Style Guide
         <div class="navbar-item">
             <div class="select">
                 <select aria-label="Select a language" id="language_selection">
-                    
+
                     <option value="" >English (US)</option>
-                    
+
                     <option value="de/" >Deutsch</option>
-                    
+
                     <option value="fr/" >Français</option>
-                    
+
                     <option value="pl/" selected>Polski</option>
-                    
+
                     <option value="pt-br/" >Português do Brasil</option>
-                    
+
                     <option value="ro/" >Română</option>
-                    
+
               </select>
             </div>
         </div>
@@ -79,110 +79,110 @@ Style Guide
 <section class="section">
 
     <header class="content block column is-offset-one-quarter pl-2">
-        
+
 <h1 class="title is-1">Style Guide</h1>
 
     </header>
     <div class="columns">
 	<nav class="menu column is-one-quarter mt-2">
             <h2 class="menu-label"><a href="/pl/">Welcome</a></h2>
-            
+
             <h2 class="menu-label">Using BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/pl/posting-statuses.html" >Zamieszczanie statusów</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/adding-books.html" >Dodawanie książek</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Running BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/pl/install-prod.html" >Installing in Production</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/install-prod-dockerless.html" >Installing Without Docker</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/updating.html" >Aktualizowanie instancji</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/moderation.html" >Moderacja</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/monitoring-queue.html" >Monitoring Queue</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/external-storage.html" >External Storage</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/optional_features.html" >Optional features</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/cli.html" >Command Line Tool</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Contributing</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/pl/contributing.html" >Udzielanie się</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/translation.html" >Tłumaczenia</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/install-dev.html" >Środowisko programistyczne</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/style_guide.html" class="is-active">Style Guide</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/debug_toolbar.html" >Django Debug Toolbar</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Codebase</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/pl/activitypub.html" >ActivityPub</a>
                 </li>
-                
+
                 <li>
                     <a href="/pl/permissions.html" >Uprawnienia</a>
                 </li>
-                
+
             </ul>
-            
+
         </nav>
 
         <div class="column">
-            
+
 <section class="block content">
     <h2>Prośby o scalenie</h2>
 <p>Jeśli chcesz udzielić się w kodzie BookWyrm, to świetnie! Jeśli istnieje otwarty problem, który chcesz naprawić, możesz zamieścić komentarz do niego, tak aby niczego nie powielać. Staraj się, aby zakres próśb o scalenie był mały i skupiony na jednym temacie. Dzięki temu łatwiej będzie ją sprawdzić i sprawniej wprowadzić zmiany.</p>
@@ -202,7 +202,7 @@ Style Guide
 <p><a href="https://eslint.org">ESLint</a> sprawdza wszelkie wprowadzone zmiany w JavaScript. Jeśli ESLint nie będzie współpracował z Twoim kodem JavaScript, sprawdź wiadomości narzędzia po więcej informacji.</p>
 <h2>Inclusive Design</h2>
 <p>Bookwyrm aims to be as inclusive and accessible as possible.</p>
-<p>When contributing code, check the <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">Inclusive Web Design Checklist</a> before you file your pull request. For accessibility advice, <a href="https://www.a11y-101.com/development">A11Y-101</a> is also a useful source. For information on how to make your page templates multi-lingual, see the <a href="/translations.html">Translations section</a>.</p>
+<p>When contributing code, check the <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">Inclusive Web Design Checklist</a> before you file your pull request. For accessibility advice, <a href="https://www.a11y-101.com/development">A11Y-101</a> is also a useful source. For information on how to make your page templates multi-lingual, see the <a href="/translation.html">Translations section</a>.</p>
 <p>Niektórymi z aspektów, które współtwórcy BookWyrm uznali za przydatne do zapamiętania są:</p>
 <h3>Formularze</h3>
 <ul>

--- a/site/pt-br/style_guide.html
+++ b/site/pt-br/style_guide.html
@@ -2,7 +2,7 @@
 <html lang="pt">
 <head>
     <title>
-        
+
 Style Guide
 
     </title>
@@ -56,19 +56,19 @@ Style Guide
         <div class="navbar-item">
             <div class="select">
                 <select aria-label="Select a language" id="language_selection">
-                    
+
                     <option value="" >English (US)</option>
-                    
+
                     <option value="de/" >Deutsch</option>
-                    
+
                     <option value="fr/" >Français</option>
-                    
+
                     <option value="pl/" >Polski</option>
-                    
+
                     <option value="pt-br/" selected>Português do Brasil</option>
-                    
+
                     <option value="ro/" >Română</option>
-                    
+
               </select>
             </div>
         </div>
@@ -79,110 +79,110 @@ Style Guide
 <section class="section">
 
     <header class="content block column is-offset-one-quarter pl-2">
-        
+
 <h1 class="title is-1">Style Guide</h1>
 
     </header>
     <div class="columns">
 	<nav class="menu column is-one-quarter mt-2">
             <h2 class="menu-label"><a href="/pt-br/">Welcome</a></h2>
-            
+
             <h2 class="menu-label">Using BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/pt-br/posting-statuses.html" >Posting statuses</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/adding-books.html" >Adding Books</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Running BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/pt-br/install-prod.html" >Installing in Production</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/install-prod-dockerless.html" >Installing Without Docker</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/updating.html" >Updating Your Instance</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/moderation.html" >Moderation</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/monitoring-queue.html" >Monitoring Queue</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/external-storage.html" >External Storage</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/optional_features.html" >Optional features</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/cli.html" >Command Line Tool</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Contributing</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/pt-br/contributing.html" >How to Contribute</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/translation.html" ></a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/install-dev.html" >Developer Environment</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/style_guide.html" class="is-active">Style Guide</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/debug_toolbar.html" >Django Debug Toolbar</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Codebase</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/pt-br/activitypub.html" >ActivityPub</a>
                 </li>
-                
+
                 <li>
                     <a href="/pt-br/permissions.html" >Permissões</a>
                 </li>
-                
+
             </ul>
-            
+
         </nav>
 
         <div class="column">
-            
+
 <section class="block content">
     <h2>Pull requests</h2>
 <p>Então você quer contribuir com a BookWyrm? Show! Se houver algum problema aberto no repositório que você quer consertar, deixer um comentário para que o trabalho não seja feito mais de uma vez. Tente manter o escopo dos pull requests pequenos e focados em uma única questão. Assim é mais fácil revisar, e se alguma parte precisar ser alterada, isso não atrapalhará as outras partes.</p>
@@ -202,7 +202,7 @@ Style Guide
 <p><a href="https://eslint.org">ESLint</a> verifica todas as modificações em JavaScript que você fizer. Se o ESLint não gostar do seu JavaScript, dê uma olhada na mensagem do linter para ver qual é o problema.</p>
 <h2>Design inclusivo</h2>
 <p>A BookWyrm quer ser o mais inclusiva e acessível possível.</p>
-<p>Quando for contribuir com código, dê uma olhada na <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">Check list de web design inclusivo</a> antes de enviar o pull request. Para sugestões de acessibilidade, o <a href="https://www.a11y-101.com/development">A11Y-101</a> também é uma fonte útil. Para saber como fazer seus templates serem compatíveis com vários idiomas, veja a <a href="/translations.html">seção Traduções</a>.</p>
+<p>Quando for contribuir com código, dê uma olhada na <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">Check list de web design inclusivo</a> antes de enviar o pull request. Para sugestões de acessibilidade, o <a href="https://www.a11y-101.com/development">A11Y-101</a> também é uma fonte útil. Para saber como fazer seus templates serem compatíveis com vários idiomas, veja a <a href="/translation.html">seção Traduções</a>.</p>
 <p>Algumas coisas que colaboradores da BookWyrm acharam boas de se lembrar:</p>
 <h3>Formulários</h3>
 <ul>

--- a/site/ro/style_guide.html
+++ b/site/ro/style_guide.html
@@ -2,7 +2,7 @@
 <html lang="ro">
 <head>
     <title>
-        
+
 Style Guide
 
     </title>
@@ -56,19 +56,19 @@ Style Guide
         <div class="navbar-item">
             <div class="select">
                 <select aria-label="Select a language" id="language_selection">
-                    
+
                     <option value="" >English (US)</option>
-                    
+
                     <option value="de/" >Deutsch</option>
-                    
+
                     <option value="fr/" >Français</option>
-                    
+
                     <option value="pl/" >Polski</option>
-                    
+
                     <option value="pt-br/" >Português do Brasil</option>
-                    
+
                     <option value="ro/" selected>Română</option>
-                    
+
               </select>
             </div>
         </div>
@@ -79,110 +79,110 @@ Style Guide
 <section class="section">
 
     <header class="content block column is-offset-one-quarter pl-2">
-        
+
 <h1 class="title is-1">Style Guide</h1>
 
     </header>
     <div class="columns">
 	<nav class="menu column is-one-quarter mt-2">
             <h2 class="menu-label"><a href="/ro/">Welcome</a></h2>
-            
+
             <h2 class="menu-label">Using BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/ro/posting-statuses.html" >Posting statuses</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/adding-books.html" >Adding Books</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Running BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/ro/install-prod.html" >Installing in Production</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/install-prod-dockerless.html" >Installing Without Docker</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/updating.html" >Updating Your Instance</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/moderation.html" >Moderation</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/monitoring-queue.html" >Monitoring Queue</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/external-storage.html" >External Storage</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/optional_features.html" >Optional features</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/cli.html" >Command Line Tool</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Contributing</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/ro/contributing.html" >How to Contribute</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/translation.html" >Translations</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/install-dev.html" >Developer Environment</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/style_guide.html" class="is-active">Style Guide</a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/debug_toolbar.html" >Django Debug Toolbar</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Codebase</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/ro/permissions.html" ></a>
                 </li>
-                
+
                 <li>
                     <a href="/ro/activitypub.html" >ActivitatePub</a>
                 </li>
-                
+
             </ul>
-            
+
         </nav>
 
         <div class="column">
-            
+
 <section class="block content">
     <h2>Cereri de extragere (pull requests)</h2>
 <p>Deci vreți să contribuiți la codul BookWyrm: super! Dacă există un tichet nerezolvat pe care ați vrea să-l rezolvați, este util să lăsați un comentariu pentru ca munca să nu fie duplicată. Încercați să păstrați obiectivul cererilor de extragere mic și concentrat pe o singură temă. În acest fel este mai ușor de revizuit, iar dacă o parte are nevoie de schimbări, nu le va bloca pe celelalte.</p>
@@ -202,7 +202,7 @@ Style Guide
 <p><a href="https://eslint.org">ESLint</a> verifică orice modificare JavaScript pe care ați făcut-o. Dacă lui ESLint nu-i place munca dvs. JavaScript, verificați mesajul linterului pentru problema exactă.</p>
 <h2>Design inclusiv</h2>
 <p>BookWyrm dorește să fie cât mai inclusiv și accesibil posibil.</p>
-<p>Când contribuiți la cod, verificați <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">lista Design Web Inclusiv</a> înainte de a depune cererea dvs. de extragere. Pentru sfaturi de accesibilitate, <a href="https://www.a11y-101.com/development">A11Y-101</a> este de asemenea o resursă utilă. Pentru informații despre cum să faceți șablonul de pagină bilingv, consultați <a href="/translations.html">secțiunea de Traduceri</a>.</p>
+<p>Când contribuiți la cod, verificați <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">lista Design Web Inclusiv</a> înainte de a depune cererea dvs. de extragere. Pentru sfaturi de accesibilitate, <a href="https://www.a11y-101.com/development">A11Y-101</a> este de asemenea o resursă utilă. Pentru informații despre cum să faceți șablonul de pagină bilingv, consultați <a href="/translation.html">secțiunea de Traduceri</a>.</p>
 <p>Câteva lucruri care li s-au părut contribuitorilor BookWyrm util de reținut sunt:</p>
 <h3>Formulare</h3>
 <ul>

--- a/site/style_guide.html
+++ b/site/style_guide.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <title>
-        
+
 Style Guide
 
     </title>
@@ -56,19 +56,19 @@ Style Guide
         <div class="navbar-item">
             <div class="select">
                 <select aria-label="Select a language" id="language_selection">
-                    
+
                     <option value="" selected>English (US)</option>
-                    
+
                     <option value="de/" >Deutsch</option>
-                    
+
                     <option value="fr/" >Français</option>
-                    
+
                     <option value="pl/" >Polski</option>
-                    
+
                     <option value="pt-br/" >Português do Brasil</option>
-                    
+
                     <option value="ro/" >Română</option>
-                    
+
               </select>
             </div>
         </div>
@@ -79,114 +79,114 @@ Style Guide
 <section class="section">
 
     <header class="content block column is-offset-one-quarter pl-2">
-        
+
 <h1 class="title is-1">Style Guide</h1>
 
     </header>
     <div class="columns">
 	<nav class="menu column is-one-quarter mt-2">
             <h2 class="menu-label"><a href="/">Welcome</a></h2>
-            
+
             <h2 class="menu-label">Using BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/posting-statuses.html" >Posting statuses</a>
                 </li>
-                
+
                 <li>
                     <a href="/adding-books.html" >Adding Books</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Running BookWyrm</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/install-prod.html" >Installing in Production</a>
                 </li>
-                
+
                 <li>
                     <a href="/install-prod-dockerless.html" >Installing Without Docker</a>
                 </li>
-                
+
                 <li>
                     <a href="/updating.html" >Updating Your Instance</a>
                 </li>
-                
+
                 <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
-                
+
                 <li>
                     <a href="/moderation.html" >Moderation</a>
                 </li>
-                
+
                 <li>
                     <a href="/monitoring-queue.html" >Monitoring Queue</a>
                 </li>
-                
+
                 <li>
                     <a href="/external-storage.html" >External Storage</a>
                 </li>
-                
+
                 <li>
                     <a href="/optional_features.html" >Optional features</a>
                 </li>
-                
+
                 <li>
                     <a href="/cli.html" >Command Line Tool</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Contributing</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/contributing.html" >How to Contribute</a>
                 </li>
-                
+
                 <li>
                     <a href="/translation.html" >Translations</a>
                 </li>
-                
+
                 <li>
                     <a href="/install-dev.html" >Developer Environment</a>
                 </li>
-                
+
                 <li>
                     <a href="/style_guide.html" class="is-active">Style Guide</a>
                 </li>
-                
+
                 <li>
                     <a href="/debug_toolbar.html" >Django Debug Toolbar</a>
                 </li>
-                
+
                 <li>
                     <a href="/codereview.html" >Code Review</a>
                 </li>
-                
+
             </ul>
-            
+
             <h2 class="menu-label">Codebase</h2>
             <ul class="menu-list">
-                
+
                 <li>
                     <a href="/activitypub.html" >ActivityPub</a>
                 </li>
-                
+
                 <li>
                     <a href="/permissions.html" >Permissions</a>
                 </li>
-                
+
             </ul>
-            
+
         </nav>
 
         <div class="column">
-            
+
 <section class="block content">
     <h2>Pull requests</h2>
 <p>So you want to contribute code to BookWyrm: that rules! If there's an open issue that you'd like to fix, it's helpful to comment on the issue so work doesn't get duplicated. Try to keep the scope of pull requests small and focused on a single topic. That way it's easier to review, and if one part needs changes, it won't hold up the other parts.</p>
@@ -206,7 +206,7 @@ Style Guide
 <p><a href="https://eslint.org">ESLint</a> checks any JavaScript changes you have made. If ESLint doesn't like your working JavaScript, check the linter message for the exact problem.</p>
 <h2>Inclusive Design</h2>
 <p>Bookwyrm aims to be as inclusive and accessible as possible.</p>
-<p>When contributing code, check the <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">Inclusive Web Design Checklist</a> before you file your pull request. For accessibility advice, <a href="https://www.a11y-101.com/development">A11Y-101</a> is also a useful source. For information on how to make your page templates multi-lingual, see the <a href="/translations.html">Translations section</a>.</p>
+<p>When contributing code, check the <a href="https://github.com/bookwyrm-social/bookwyrm/discussions/1354">Inclusive Web Design Checklist</a> before you file your pull request. For accessibility advice, <a href="https://www.a11y-101.com/development">A11Y-101</a> is also a useful source. For information on how to make your page templates multi-lingual, see the <a href="/translation.html">Translations section</a>.</p>
 <p>Some particular things that Bookwyrm contributors have found useful to remember are:</p>
 <h3>Forms</h3>
 <ul>


### PR DESCRIPTION
- "Translations section" on [this page](https://docs.joinbookwyrm.com/style_guide.html) leads to a non-existent page. Changed `translations` to `translation`.
- Some style changes for non-English translations. 