### PR TITLE
Update dockerless installation docs and add dockerless update docs

### DIFF
--- a/content/running_bookwyrm/cli.md
+++ b/content/running_bookwyrm/cli.md
@@ -1,7 +1,7 @@
 ---
 Title: Command Line Tool
 Date: 2021-11-11
-Order: 9
+Order: 10
 ---
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.

--- a/content/running_bookwyrm/external-storage.md
+++ b/content/running_bookwyrm/external-storage.md
@@ -1,7 +1,7 @@
 ---
 Title: External Storage
 Date: 2021-06-07
-Order: 7
+Order: 8
 ---
 
 By default, BookWyrm uses local storage for static assets (favicon, default avatar, etc.), and media (user avatars, book covers, etc.), but you can use an external storage service to serve these files. BookWyrm uses `django-storages` to handle external storage, such as S3-compatible services, Apache Libcloud or SFTP.

--- a/content/running_bookwyrm/install-prod-dockerless.md
+++ b/content/running_bookwyrm/install-prod-dockerless.md
@@ -22,10 +22,8 @@ Instructions for running BookWyrm in production without Docker:
 
 - Make and enter directory you want to install bookwyrm too. For example `/opt/bookwyrm`:
 	`mkdir /opt/bookwyrm && cd /opt/bookwyrm`
-- Get the application code:
-    `git clone git@github.com:bookwyrm-social/bookwyrm.git ./`
-- Switch to the `production` branch:
-    `git checkout production`
+- Get the application code, note that this only clones the `production` branch:
+    `git clone https://github.com/bookwyrm-social/bookwyrm.git --branch production --single-branch ./`
 - Create your environment variables file, `cp .env.example .env`, and update the following:
     - `SECRET_KEY` | A difficult to guess, secret string of characters
     - `DOMAIN` | Your web domain
@@ -44,10 +42,12 @@ Instructions for running BookWyrm in production without Docker:
     - Make a copy of the production template config and set it for use in nginx: `cp nginx/production /etc/nginx/sites-available/bookwyrm.conf`
     - Update nginx `bookwyrm.conf`:
         - Replace `your-domain.com` with your domain name everywhere in the file (including the lines that are currently commented out)
-        - Replace `/app/` with your install directory `/opt/bookwyrm/` everywhere in the file (including commented out)
-        - Uncomment lines 18 to 67 to enable forwarding to HTTPS. You should have two `server` blocks enabled
+        - Replace `/app` with your install directory `/opt/bookwyrm` everywhere in the file (including commented out)
+        - Uncomment [lines 23 to 111](https://github.com/bookwyrm-social/bookwyrm/blob/production/nginx/production#L23-L111) to enable
+            forwarding to HTTPS. You should have two `server` blocks enabled
         - Change the `ssl_certificate` and `ssl_certificate_key` paths to your fullchain and privkey locations
-        - Change line 4 so that it says `server localhost:8000`. You may choose a different port here if you wish
+        - Change [line 4](https://github.com/chdorner/secretbearlibrary/blob/main/bookwyrm/bookwyrm-nginx.conf#L4) so that it says
+            `server localhost:8000`. You may choose a different port here if you wish
         - If you are running another web-server on your host machine, you will need to follow the [reverse-proxy instructions](/reverse-proxy.html)
     - Enable the nginx config:
         `ln -s /etc/nginx/sites-available/bookwyrm.conf /etc/nginx/sites-enabled/bookwyrm.conf`

--- a/content/running_bookwyrm/install-prod-dockerless.md
+++ b/content/running_bookwyrm/install-prod-dockerless.md
@@ -102,6 +102,27 @@ c6c35779-af3a-4091-b330-c026610920d6
 
 Congrats! You did it!! Configure your instance however you'd like.
 
+## Finding log files
+
+Like all software, BookWyrm can contain bugs, and often these bugs are in the Python code and easiest to reproduce by getting more context from the logs.
+
+If you use the provided `systemd` service configurations from `contrib/systemd` you will be able to read the logs with `journalctl`:
+
+``` { .sh}
+# viewing logs of the web process
+journalctl -u bookwyrm
+
+# viewing logs of the worker process
+journalctl -u bookwyrm-worker
+
+# viewing logs of the scheduler process
+journalctl -u bookwyrm-scheduler
+```
+Feel free to explore additional ways of slicing and dicing logs with flags documented in `journalctl --help`.
+
+While BookWyrm's application logs will most often be enough, you can find logs for other services like Nginx,
+PostgreSQL, or Redis are usually in `.log` files located somewhere in `/var/logs`.
+
 ## Get Involved
 
 See [Get Involved](https://joinbookwyrm.com/get-involved/) for details.

--- a/content/running_bookwyrm/moderation.md
+++ b/content/running_bookwyrm/moderation.md
@@ -1,7 +1,7 @@
 ---
 Title: Moderation
 Date: 2021-04-18
-Order: 5
+Order: 6
 ---
 
 ## Blocking

--- a/content/running_bookwyrm/monitoring-queue.md
+++ b/content/running_bookwyrm/monitoring-queue.md
@@ -1,7 +1,7 @@
 ---
 Title: Monitoring Queue
 Date: 2022-11-23
-Order: 6
+Order: 7
 ---
 
 There might be occurences where your instances behaves slowly. One option would

--- a/content/running_bookwyrm/optional_features.md
+++ b/content/running_bookwyrm/optional_features.md
@@ -1,7 +1,7 @@
 ---
 Title: Optional features
 Date: 2021-08-02
-Order: 8
+Order: 9
 ---
 
 Some features of BookWyrm have to be enabled to work.

--- a/content/running_bookwyrm/reverse-proxy.md
+++ b/content/running_bookwyrm/reverse-proxy.md
@@ -1,7 +1,7 @@
 ---
 Title: Using a Reverse-Proxy
 Date: 2021-05-11
-Order: 4
+Order: 5
 ---
 
 ## Running BookWyrm Behind a Reverse-Proxy
@@ -112,4 +112,3 @@ If everything worked correctly, your BookWyrm instance should now be externally 
 *Note: the `proxy_set_header Host $host;` is essential; if you do not include it, incoming messages from federated servers will be rejected.*
 
 *Note: the location of the ssl certificates may vary depending on the OS of your server*
-

--- a/content/running_bookwyrm/updating-dockerless.md
+++ b/content/running_bookwyrm/updating-dockerless.md
@@ -1,0 +1,19 @@
+---
+Title: Updating Without Docker
+Date: 2023-01-29
+Order: 4
+---
+
+Follow this guide if you have a BookWyrm installation without Docker and
+there are changes available in the production branch.
+
+This guide assumes that your setup followed the latest [Installation without Docker](/install-prod-dockerless.html) guide.
+
+Run all the following commands, except otherwise noted, as the `bookwyrm` user:
+
+1. Pull in the latest changes on the `production` branch with `git pull`
+2. Install potential new Python dependencies `venv/bin/pip install -r requirements.txt`
+3. Compile the themes with `venv/bin/python3 manage.py compile_themes`
+4. Collecting all the static files with `venv/bin/python3 manage.py collectstatic --no-input` – this also uploads them to [external storage](/external-storage.html) if you have this configured
+5. Migrate the database (it's advisable to create a backup before) with `venv/bin/python3 manage.py migrate`
+6. Restart the `systemd` services with `sudo systemctl restart bookwyrm bookwyrm-worker bookwyrm-scheduler`

--- a/site/activitypub.html
+++ b/site/activitypub.html
@@ -116,6 +116,10 @@ ActivityPub
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/adding-books.html
+++ b/site/adding-books.html
@@ -116,6 +116,10 @@ Adding Books
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/cli.html
+++ b/site/cli.html
@@ -116,6 +116,10 @@ Command Line Tool
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -116,6 +116,10 @@ How to Contribute
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/debug_toolbar.html
+++ b/site/debug_toolbar.html
@@ -116,6 +116,10 @@ Django Debug Toolbar
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/external-storage.html
+++ b/site/external-storage.html
@@ -116,6 +116,10 @@ External Storage
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/index.html
+++ b/site/index.html
@@ -119,6 +119,10 @@
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/install-dev.html
+++ b/site/install-dev.html
@@ -116,6 +116,10 @@ Developer Environment
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/install-prod-dockerless.html
+++ b/site/install-prod-dockerless.html
@@ -116,6 +116,10 @@ Installing Without Docker
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 
@@ -204,10 +208,8 @@ This install method assumes you already have ssl configured with certificates av
 <ul>
 <li>Make and enter directory you want to install bookwyrm too. For example <code>/opt/bookwyrm</code>:
     <code>mkdir /opt/bookwyrm &amp;&amp; cd /opt/bookwyrm</code></li>
-<li>Get the application code:
-    <code>git clone git@github.com:bookwyrm-social/bookwyrm.git ./</code></li>
-<li>Switch to the <code>production</code> branch:
-    <code>git checkout production</code></li>
+<li>Get the application code, note that this only clones the <code>production</code> branch:
+    <code>git clone https://github.com/bookwyrm-social/bookwyrm.git --branch production --single-branch ./</code></li>
 <li>Create your environment variables file, <code>cp .env.example .env</code>, and update the following:<ul>
 <li><code>SECRET_KEY</code> | A difficult to guess, secret string of characters</li>
 <li><code>DOMAIN</code> | Your web domain</li>
@@ -228,10 +230,12 @@ This install method assumes you already have ssl configured with certificates av
 <li>Make a copy of the production template config and set it for use in nginx: <code>cp nginx/production /etc/nginx/sites-available/bookwyrm.conf</code></li>
 <li>Update nginx <code>bookwyrm.conf</code>:<ul>
 <li>Replace <code>your-domain.com</code> with your domain name everywhere in the file (including the lines that are currently commented out)</li>
-<li>Replace <code>/app/</code> with your install directory <code>/opt/bookwyrm/</code> everywhere in the file (including commented out)</li>
-<li>Uncomment lines 18 to 67 to enable forwarding to HTTPS. You should have two <code>server</code> blocks enabled</li>
+<li>Replace <code>/app</code> with your install directory <code>/opt/bookwyrm</code> everywhere in the file (including commented out)</li>
+<li>Uncomment <a href="https://github.com/bookwyrm-social/bookwyrm/blob/production/nginx/production#L23-L111">lines 23 to 111</a> to enable
+    forwarding to HTTPS. You should have two <code>server</code> blocks enabled</li>
 <li>Change the <code>ssl_certificate</code> and <code>ssl_certificate_key</code> paths to your fullchain and privkey locations</li>
-<li>Change line 4 so that it says <code>server localhost:8000</code>. You may choose a different port here if you wish</li>
+<li>Change <a href="https://github.com/chdorner/secretbearlibrary/blob/main/bookwyrm/bookwyrm-nginx.conf#L4">line 4</a> so that it says
+    <code>server localhost:8000</code>. You may choose a different port here if you wish</li>
 <li>If you are running another web-server on your host machine, you will need to follow the <a href="/reverse-proxy.html">reverse-proxy instructions</a></li>
 </ul>
 </li>
@@ -242,18 +246,16 @@ This install method assumes you already have ssl configured with certificates av
 </li>
 <li>Setup the python virtual enviroment<ul>
 <li>Make the python venv directory in your install dir:
-    <code>mkdir venv</code>
     <code>python3 -m venv ./venv</code></li>
 <li>Install bookwyrm python dependencies with pip:
     <code>./venv/bin/pip3 install -r requirements.txt</code></li>
 </ul>
 </li>
-<li>
-<p>Make the bookwyrm postgresql database. Make sure to change the password to what you set in the <code>.env</code> config:</p>
-<p><code>sudo -i -u postgres psql</code></p>
-</li>
+<li>Make the bookwyrm postgresql database. Make sure to change the password to what you set in the <code>.env</code> config:
+    <code>sudo -i -u postgres psql</code></li>
 </ul>
-<pre><code>CREATE USER bookwyrm WITH PASSWORD 'securedbypassword123';
+<pre><code class="language-sql">-- make sure to replace the password with your POSTGRES_PASSWORD .env setting
+CREATE USER bookwyrm WITH PASSWORD 'securedbypassword123';
 
 CREATE DATABASE bookwyrm TEMPLATE template0 ENCODING 'UNICODE';
 
@@ -269,15 +271,20 @@ GRANT ALL PRIVILEGES ON DATABASE bookwyrm TO bookwyrm;
 <li>Compile the themes by running <code>venv/bin/python3 manage.py compile_themes</code></li>
 <li>Create the static files by running <code>venv/bin/python3 manage.py collectstatic --no-input</code></li>
 <li>If you wish to use an external storage for static assets and media files (such as an S3-compatible service), <a href="/external-storage.html">follow the instructions</a> until it tells you to come back here</li>
-<li>
-<p>Create and setup your <code>bookwyrm</code> user</p>
-<ul>
+<li>Create and setup your <code>bookwyrm</code> user<ul>
 <li>Make the system bookwyrm user:
     <code>useradd bookwyrm -r</code></li>
 <li>Change the owner of your install directory to bookwyrm:
     <code>chown -R bookwyrm:bookwyrm /opt/bookwyrm</code></li>
 <li>You should now run bookwyrm related commands as the bookwyrm user:
     <code>sudo -u bookwyrm echo I am the $(whoami) user</code></li>
+</ul>
+</li>
+<li>
+<p>Configure, enable, and start BookWyrm's <code>systemd</code> services:</p>
+<ul>
+<li>Copy the service configurations by running <code>cp contrib/systemd/*.service /etc/systemd/system/</code></li>
+<li>Enable and start the services with <code>systemctl enable bookwyrm bookwyrm-worker bookwyrm-scheduler</code></li>
 </ul>
 </li>
 <li>
@@ -291,52 +298,24 @@ c6c35779-af3a-4091-b330-c026610920d6
 *******************************************
 </code></pre>
 <ul>
-<li>Make and configure the run script<ul>
-<li>Make a file called dockerless-run.sh and fill it with the following contents</li>
+<li>The application should now be running at your domain. When you load the domain, you should get a configuration page to confirm your instance settings, and a form to create an admin account. Use your admin code to register.</li>
 </ul>
-</li>
-</ul>
-<pre><code class="language-sh">#!/bin/bash
-
-# stop if one process fails
-set -e
-
-# bookwyrm
-/opt/bookwyrm/venv/bin/gunicorn bookwyrm.wsgi:application --bind 0.0.0.0:8000 &amp;
-
-# celery
-/opt/bookwyrm/venv/bin/celery -A celerywyrm worker -l info -Q high_priority,medium_priority,low_priority,imports &amp;
-/opt/bookwyrm/venv/bin/celery -A celerywyrm beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler &amp;
-# /opt/bookwyrm/venv/bin/celery -A celerywyrm flower &amp;
-</code></pre>
-<pre><code>- Replace `/opt/bookwyrm` with your install dir
-- Change `8000` to your custom port number
-- Flower has been disabled here because it is not autoconfigured with the password set in the `.env` file
-</code></pre>
-<ul>
-<li>You can now run BookWyrm with: <code>sudo -u bookwyrm bash /opt/bookwyrm/dockerless-run.sh</code></li>
-<li>The application should be running at your domain. When you load the domain, you should get a configuration page which confirms your instance settings, and a form to create an admin account. Use your admin code to register.</li>
-<li>You may want to configure BookWyrm to autorun with a systemd service. Here is an example:</li>
-</ul>
-<pre><code># /etc/systemd/system/bookwyrm.service
-[Unit]
-Description=Bookwyrm Server
-After=network.target
-After=systemd-user-sessions.service
-After=network-online.target
-
-[Service]
-User=bookwyrm
-Type=simple
-Restart=always
-ExecStart=/bin/bash /opt/bookwyrm/dockerless-run.sh
-WorkingDirectory=/opt/bookwyrm/
-
-[Install]
-WantedBy=multi-user.target
-</code></pre>
-<p>You will need to set up a Cron job for the service to start automatically on a server restart.</p>
 <p>Congrats! You did it!! Configure your instance however you'd like.</p>
+<h2>Finding log files</h2>
+<p>Like all software, BookWyrm can contain bugs, and often these bugs are in the Python code and easiest to reproduce by getting more context from the logs.</p>
+<p>If you use the provided <code>systemd</code> service configurations from <code>contrib/systemd</code> you will be able to read the logs with <code>journalctl</code>:</p>
+<pre><code class="language-sh"># viewing logs of the web process
+journalctl -u bookwyrm
+
+# viewing logs of the worker process
+journalctl -u bookwyrm-worker
+
+# viewing logs of the scheduler process
+journalctl -u bookwyrm-scheduler
+</code></pre>
+<p>Feel free to explore additional ways of slicing and dicing logs with flags documented in <code>journalctl --help</code>.</p>
+<p>While BookWyrm's application logs will most often be enough, you can find logs for other services like Nginx,
+PostgreSQL, or Redis are usually in <code>.log</code> files located somewhere in <code>/var/logs</code>.</p>
 <h2>Get Involved</h2>
 <p>See <a href="https://joinbookwyrm.com/get-involved/">Get Involved</a> for details.</p>
 </section>

--- a/site/install-prod.html
+++ b/site/install-prod.html
@@ -116,6 +116,10 @@ Installing in Production
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/moderation.html
+++ b/site/moderation.html
@@ -116,6 +116,10 @@ Moderation
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/monitoring-queue.html
+++ b/site/monitoring-queue.html
@@ -116,6 +116,10 @@ Monitoring Queue
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/optional_features.html
+++ b/site/optional_features.html
@@ -116,6 +116,10 @@ Optional features
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/permissions.html
+++ b/site/permissions.html
@@ -116,6 +116,10 @@ Permissions
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/posting-statuses.html
+++ b/site/posting-statuses.html
@@ -116,6 +116,10 @@ Posting statuses
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/reverse-proxy.html
+++ b/site/reverse-proxy.html
@@ -116,6 +116,10 @@ Using a Reverse-Proxy
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" class="is-active">Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/style_guide.html
+++ b/site/style_guide.html
@@ -116,6 +116,10 @@ Style Guide
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/translation.html
+++ b/site/translation.html
@@ -116,6 +116,10 @@ Translations
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 

--- a/site/updating-dockerless.html
+++ b/site/updating-dockerless.html
@@ -3,7 +3,7 @@
 <head>
     <title>
         
-Code Review
+Updating Without Docker
 
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -80,7 +80,7 @@ Code Review
 
     <header class="content block column is-offset-one-quarter pl-2">
         
-<h1 class="title is-1">Code Review</h1>
+<h1 class="title is-1">Updating Without Docker</h1>
 
     </header>
     <div class="columns">
@@ -116,7 +116,7 @@ Code Review
                 </li>
                 
                 <li>
-                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                    <a href="/updating-dockerless.html" class="is-active">Updating Without Docker</a>
                 </li>
                 
                 <li>
@@ -169,7 +169,7 @@ Code Review
                 </li>
                 
                 <li>
-                    <a href="/codereview.html" class="is-active">Code Review</a>
+                    <a href="/codereview.html" >Code Review</a>
                 </li>
                 
             </ul>
@@ -192,22 +192,18 @@ Code Review
         <div class="column">
             
 <section class="block content">
-    <p>You opened a pull request! Thank you so much. Here's what happens next. Long story short, another contributor will look over your code, try it out, and give feedback until it's ready to merge. Here's some more detail on the process:</p>
-<h2>Automated Checks</h2>
-<p>BookWyrm uses a handful of <a href="style_guide.html">code validators</a> that lint and validate code, and run the unit tests. All of these need to pass for your code to be ready to merge. There are usually hints about how you can fix any checks that don't pass, but if you aren't sure how to proceed, just comment on the issue and someone can help you out.</p>
-<h2>Code Review</h2>
-<p>When your code is ready for review, a contributor will take a look at what you've written. They will be looking for a few things:</p>
-<ul>
-<li>Is your proposed change in line with the project's goals?</li>
-<li>Does your code work as expected?</li>
-<li>Are there different or more efficient approaches you could have taken?</li>
-<li>Are there edge cases you may have overlooked?</li>
-<li>If you added any text, is it <a href="translation.html">correctly internationalized</a>?</li>
-<li>If you made UI changes, are they clearly navigable with a screen reader?</li>
-</ul>
-<p>This is also a chance for other contributors to ask you questions about anything they don't understand or are curious about in your code.</p>
-<h2>Merging</h2>
-<p>Once you and the reviewer feel good about your code, the reviewer will merge it. It won't be immediately available in production, but will go into the next release.</p>
+    <p>Follow this guide if you have a BookWyrm installation without Docker and
+there are changes available in the production branch.</p>
+<p>This guide assumes that your setup followed the latest <a href="/install-prod-dockerless.html">Installation without Docker</a> guide.</p>
+<p>Run all the following commands, except otherwise noted, as the <code>bookwyrm</code> user:</p>
+<ol>
+<li>Pull in the latest changes on the <code>production</code> branch with <code>git pull</code></li>
+<li>Install potential new Python dependencies <code>venv/bin/pip install -r requirements.txt</code></li>
+<li>Compile the themes with <code>venv/bin/python3 manage.py compile_themes</code></li>
+<li>Collecting all the static files with <code>venv/bin/python3 manage.py collectstatic --no-input</code> – this also uploads them to <a href="/external-storage.html">external storage</a> if you have this configured</li>
+<li>Migrate the database (it's advisable to create a backup before) with <code>venv/bin/python3 manage.py migrate</code></li>
+<li>Restart the <code>systemd</code> services with <code>sudo systemctl restart bookwyrm bookwyrm-worker bookwyrm-scheduler</code></li>
+</ol>
 </section>
 
         </div>

--- a/site/updating.html
+++ b/site/updating.html
@@ -116,6 +116,10 @@ Updating Your Instance
                 </li>
                 
                 <li>
+                    <a href="/updating-dockerless.html" >Updating Without Docker</a>
+                </li>
+                
+                <li>
                     <a href="/reverse-proxy.html" >Using a Reverse-Proxy</a>
                 </li>
                 


### PR DESCRIPTION
I took the liberty and replaced the old `dockerless.sh` part with our newly bundled `contrib/systemd` services.

General docs PR question: do I need to compile and add the updated HTML files as well?