### PR TITLE
Fix confirm_email and remove_2fa commands

### DIFF
--- a/content/running_bookwyrm/cli.md
+++ b/content/running_bookwyrm/cli.md
@@ -173,10 +173,10 @@ Compiles translation files. See [Django's compilemessages](https://docs.djangopr
 
 Run tests with `pytest`.
 
-### deactivate_2fa
+### remove_2fa
 
 Deactivates two factor authentication for a given user.
 
-### manual_confirm
+### confirm_email
 
 Confirms a users email, sets the user to active.


### PR DESCRIPTION
Confirm Email and 2FA commands are wrong in the documentation.