### PR TITLE
install deps on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
     - name: Deploy to server
       id: deploy
       uses: Pendect/action-rsyncer@v1.1.0


### PR DESCRIPTION
If the `requirements.txt` is changed in the repo, the new dependencies need to be installed on the production server. This didn't happen with #106 hence the fix didn't affect the actual docs page.

I'm not super confident with GitHub actions so I'm just assuming this fix will do what I expect...