### PR TITLE
fix nested list indenting

### DIFF
--- a/content/using_bookwyrm/posting-statuses.md
+++ b/content/using_bookwyrm/posting-statuses.md
@@ -37,9 +37,9 @@ Text can include:
 - Mentions (@user)
 - URLs (`http(s)://` is not displayed)
 - Some [Markdown formatting](https://www.markdownguide.org/cheat-sheet/)
-  - bold
-  - italics
-  - block quotes
-  - bullet lists
-  - links
+    - bold
+    - italics
+    - block quotes
+    - bullet lists
+    - links
 


### PR DESCRIPTION
Nested lists need to be indented by 4 spaces, not two: https://www.markdownguide.org/basic-syntax/#adding-elements-in-lists 

fixes #103