### PR TITLE
build and deploy together

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,15 +41,6 @@ jobs:
           commit_message: build site
           commit_author: BookWyrm Bot <joinbookwyrm@users.noreply>
 
-  deploy:
-    needs: compile
-    runs-on: ubuntu-latest
-
-    steps:
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
       - name: Deploy to server
         id: deploy
         uses: Pendect/action-rsyncer@v2.0.0


### PR DESCRIPTION
Separately building and committing, and then deploying, ends up deploying the code prior to the committed code. This change builds the site, commits the built code back to the repository, and deploys the updated code to the server. Or at least that's the plan.