### PR TITLE
restructure deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,56 +26,9 @@ jobs:
             quoted+=("\"$line\"")
           done
           str=$( IFS=$','; echo "${quoted[*]}" )
-          echo "versions=[$str]" >> $GITHUB_OUTPUT
+          echo "versions=[\"main\",$str]" >> $GITHUB_OUTPUT
 
-  compile-latest:
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Install Dev Dependencies
-        run: |
-          sudo apt-get install gettext
-
-      - name: Install Python Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Process translations
-        run: |
-          ./bw-dev messages:update
-
-      - name: Compile site
-        run: |
-          python generate.py
-
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_user_name: BookWyrm Bot
-          commit_message: deploy latest
-          commit_author: BookWyrm Bot <joinbookwyrm@users.noreply>
-
-      - name: Deploy to server
-        id: deploy-latest
-        uses: Pendect/action-rsyncer@v2.0.0
-        env:
-          DEPLOY_KEY: ${{secrets.DEPLOY_KEY}}
-        with:
-          flags: '-avzr --delete'
-          options: ''
-          ssh_options: ''
-          src: 'site/'
-          dest: 'mouse@docs.joinbookwyrm.com:/var/www/docs-bookwyrm/html'
-
-  compile-versions:
+  compile:
     runs-on: ubuntu-latest
     needs: get-versions
     strategy:
@@ -116,7 +69,21 @@ jobs:
           commit_message: deploy versions
           commit_author: BookWyrm Bot <joinbookwyrm@users.noreply>
 
-      - name: Deploy to server
+      - name: Deploy latest to server
+        if:  ${{ matrix.version == 'main' }}
+        id: deploy-versions
+        uses: Pendect/action-rsyncer@v2.0.0
+        env:
+          DEPLOY_KEY: ${{secrets.DEPLOY_KEY}}
+        with:
+          flags: '-avzr --delete --exclude="v*[0-9\.]/**"'
+          options: ''
+          ssh_options: ''
+          src: 'site/'
+          dest: 'mouse@docs.joinbookwyrm.com:/var/www/docs-bookwyrm/html'
+
+      - name: Deploy versions to server
+        if:  ${{ matrix.version != 'main' }}
         id: deploy-versions
         uses: Pendect/action-rsyncer@v2.0.0
         env:

--- a/generate.py
+++ b/generate.py
@@ -124,8 +124,8 @@ def format_markdown(file_path):
 
 
 if __name__ == "__main__":
-    # when we generate for older versions we need to change the page links
-    version = sys.argv[1] if len(sys.argv) > 1 else False
+    # when we generate for versions we need to change the page links
+    version = sys.argv[1] if (len(sys.argv) > 1 and sys.argv[1] != "main") else False
     # iterate through each locale
     for locale in i18n.locales_metadata:
         SLUG = locale["slug"]


### PR DESCRIPTION
It is cleaner to run all tasks in one matrix.
We add `main` as a version but sync to the server without a version subdirectory. We exclude the version subdirectories from the `main` rsync --delete because matrix jobs are not guaranteed to run in a particular order. If we don't do this it can wipe out the versions after they are copied over.