### PR TITLE
Fix broken links

### DIFF
--- a/content/contributing/contributing.md
+++ b/content/contributing/contributing.md
@@ -56,7 +56,7 @@ Code contributions are gladly welcomed! If you're not sure where to start, take 
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/content/reference/cli.md
+++ b/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/content/reference/cli.md
+++ b/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/content/reference/cli.md
+++ b/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/af_ZA/content/running_bookwyrm/cli.md
+++ b/locale/af_ZA/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/af_ZA/content/running_bookwyrm/cli.md
+++ b/locale/af_ZA/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/af_ZA/content/running_bookwyrm/cli.md
+++ b/locale/af_ZA/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/ar_SA/content/running_bookwyrm/cli.md
+++ b/locale/ar_SA/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/ar_SA/content/running_bookwyrm/cli.md
+++ b/locale/ar_SA/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/ar_SA/content/running_bookwyrm/cli.md
+++ b/locale/ar_SA/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/ba_RU/content/running_bookwyrm/cli.md
+++ b/locale/ba_RU/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/ba_RU/content/running_bookwyrm/cli.md
+++ b/locale/ba_RU/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/ba_RU/content/running_bookwyrm/cli.md
+++ b/locale/ba_RU/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/bn_BD/content/running_bookwyrm/cli.md
+++ b/locale/bn_BD/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/bn_BD/content/running_bookwyrm/cli.md
+++ b/locale/bn_BD/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/bn_BD/content/running_bookwyrm/cli.md
+++ b/locale/bn_BD/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/bn_IN/content/running_bookwyrm/cli.md
+++ b/locale/bn_IN/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/bn_IN/content/running_bookwyrm/cli.md
+++ b/locale/bn_IN/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/bn_IN/content/running_bookwyrm/cli.md
+++ b/locale/bn_IN/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/ca_ES/content/running_bookwyrm/cli.md
+++ b/locale/ca_ES/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/ca_ES/content/running_bookwyrm/cli.md
+++ b/locale/ca_ES/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/cdo/content/running_bookwyrm/cli.md
+++ b/locale/cdo/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/cdo/content/running_bookwyrm/cli.md
+++ b/locale/cdo/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/cdo/content/running_bookwyrm/cli.md
+++ b/locale/cdo/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/cs_CZ/content/running_bookwyrm/cli.md
+++ b/locale/cs_CZ/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/cs_CZ/content/running_bookwyrm/cli.md
+++ b/locale/cs_CZ/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/cs_CZ/content/running_bookwyrm/cli.md
+++ b/locale/cs_CZ/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/cy_GB/content/running_bookwyrm/cli.md
+++ b/locale/cy_GB/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/cy_GB/content/running_bookwyrm/cli.md
+++ b/locale/cy_GB/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/cy_GB/content/running_bookwyrm/cli.md
+++ b/locale/cy_GB/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/da_DK/content/running_bookwyrm/cli.md
+++ b/locale/da_DK/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/da_DK/content/running_bookwyrm/cli.md
+++ b/locale/da_DK/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/da_DK/content/running_bookwyrm/cli.md
+++ b/locale/da_DK/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/de_DE/content/contributing/contributing.md
+++ b/locale/de_DE/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Codebeiträge sind herzlich willkommen! Wenn du nicht weißt, wo du anfangen sol
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/de_DE/content/reference/cli.md
+++ b/locale/de_DE/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/de_DE/content/reference/cli.md
+++ b/locale/de_DE/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/de_DE/content/reference/cli.md
+++ b/locale/de_DE/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/de_DE/content/running_bookwyrm/cli.md
+++ b/locale/de_DE/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/el_GR/content/running_bookwyrm/cli.md
+++ b/locale/el_GR/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/el_GR/content/running_bookwyrm/cli.md
+++ b/locale/el_GR/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Συντομεύσεις πληκτρολογίου
 

--- a/locale/el_GR/content/running_bookwyrm/cli.md
+++ b/locale/el_GR/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/en_Oulipo/content/contributing/contributing.md
+++ b/locale/en_Oulipo/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Code contributions are gladly welcomed! If you're not sure where to start, take 
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/en_Oulipo/content/reference/cli.md
+++ b/locale/en_Oulipo/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/en_Oulipo/content/reference/cli.md
+++ b/locale/en_Oulipo/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/en_Oulipo/content/reference/cli.md
+++ b/locale/en_Oulipo/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/en_Oulipo/content/running_bookwyrm/cli.md
+++ b/locale/en_Oulipo/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/en_Oulipo/content/running_bookwyrm/cli.md
+++ b/locale/en_Oulipo/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/en_Oulipo/content/running_bookwyrm/cli.md
+++ b/locale/en_Oulipo/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/es_ES/content/contributing/contributing.md
+++ b/locale/es_ES/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Bibliographic metadata wizard? Celery nerd? ActivityPub expert? SQL query obsess
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/es_ES/content/reference/cli.md
+++ b/locale/es_ES/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/es_ES/content/reference/cli.md
+++ b/locale/es_ES/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/es_ES/content/reference/cli.md
+++ b/locale/es_ES/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/es_ES/content/running_bookwyrm/cli.md
+++ b/locale/es_ES/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/es_ES/content/running_bookwyrm/cli.md
+++ b/locale/es_ES/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/es_ES/content/running_bookwyrm/cli.md
+++ b/locale/es_ES/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/eu_ES/content/running_bookwyrm/cli.md
+++ b/locale/eu_ES/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/eu_ES/content/running_bookwyrm/cli.md
+++ b/locale/eu_ES/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/eu_ES/content/running_bookwyrm/cli.md
+++ b/locale/eu_ES/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/fi_FI/content/contributing/contributing.md
+++ b/locale/fi_FI/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Code contributions are gladly welcomed! If you're not sure where to start, take 
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/fi_FI/content/reference/cli.md
+++ b/locale/fi_FI/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/fi_FI/content/reference/cli.md
+++ b/locale/fi_FI/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/fi_FI/content/reference/cli.md
+++ b/locale/fi_FI/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/fi_FI/content/running_bookwyrm/cli.md
+++ b/locale/fi_FI/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/fi_FI/content/running_bookwyrm/cli.md
+++ b/locale/fi_FI/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/fi_FI/content/running_bookwyrm/cli.md
+++ b/locale/fi_FI/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/fr_FR/content/contributing/contributing.md
+++ b/locale/fr_FR/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Les contributions au code sont bienvenues ! Si vous ne savez pas par où comme
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/fr_FR/content/reference/cli.md
+++ b/locale/fr_FR/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/fr_FR/content/reference/cli.md
+++ b/locale/fr_FR/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/fr_FR/content/reference/cli.md
+++ b/locale/fr_FR/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/fr_FR/content/running_bookwyrm/cli.md
+++ b/locale/fr_FR/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm utilise [Prettier](https://prettier.io/) pour assurer la cohérence du 
 
 ### stylelint
 
-BookWyrm utilise [Stylelint](uhttps://stylelint.io/) pour assurer la cohérence des fichiers CSS. Exécutez `stylelintprettier` avant de valider vos modifications de scripts afin de formater automatiquement votre code.
+BookWyrm utilise [Stylelint](https://stylelint.io/) pour assurer la cohérence des fichiers CSS. Exécutez `stylelintprettier` avant de valider vos modifications de scripts afin de formater automatiquement votre code.
 
 ### formatters
 

--- a/locale/gl_ES/content/contributing/contributing.md
+++ b/locale/gl_ES/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Agradecemos as contribucións ao código! Se non sabes por onde comezar, mira a 
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/gl_ES/content/reference/cli.md
+++ b/locale/gl_ES/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/gl_ES/content/reference/cli.md
+++ b/locale/gl_ES/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/gl_ES/content/reference/cli.md
+++ b/locale/gl_ES/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/gl_ES/content/running_bookwyrm/cli.md
+++ b/locale/gl_ES/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/gl_ES/content/running_bookwyrm/cli.md
+++ b/locale/gl_ES/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/gl_ES/content/running_bookwyrm/cli.md
+++ b/locale/gl_ES/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/he_IL/content/running_bookwyrm/cli.md
+++ b/locale/he_IL/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/he_IL/content/running_bookwyrm/cli.md
+++ b/locale/he_IL/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/he_IL/content/running_bookwyrm/cli.md
+++ b/locale/he_IL/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/hu_HU/content/running_bookwyrm/cli.md
+++ b/locale/hu_HU/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/hu_HU/content/running_bookwyrm/cli.md
+++ b/locale/hu_HU/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/hu_HU/content/running_bookwyrm/cli.md
+++ b/locale/hu_HU/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/it_IT/content/contributing/contributing.md
+++ b/locale/it_IT/content/contributing/contributing.md
@@ -54,7 +54,7 @@ I contributi al codice vengono accolti con piacere! Se non sei sicuro di dove in
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/it_IT/content/reference/cli.md
+++ b/locale/it_IT/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/it_IT/content/reference/cli.md
+++ b/locale/it_IT/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/it_IT/content/reference/cli.md
+++ b/locale/it_IT/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/it_IT/content/running_bookwyrm/cli.md
+++ b/locale/it_IT/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/it_IT/content/running_bookwyrm/cli.md
+++ b/locale/it_IT/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Genera un'anteprima per siti, utenti e libri. Può richiedere un po' di tempo se
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/ja_JP/content/running_bookwyrm/cli.md
+++ b/locale/ja_JP/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/ja_JP/content/running_bookwyrm/cli.md
+++ b/locale/ja_JP/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/ja_JP/content/running_bookwyrm/cli.md
+++ b/locale/ja_JP/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/ko_KR/content/running_bookwyrm/cli.md
+++ b/locale/ko_KR/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/ko_KR/content/running_bookwyrm/cli.md
+++ b/locale/ko_KR/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/ko_KR/content/running_bookwyrm/cli.md
+++ b/locale/ko_KR/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/lt_LT/content/contributing/contributing.md
+++ b/locale/lt_LT/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Kodo prisidėjimai labai laukiami! Jei nežinote, nuo ko pradėti, pažiūrėkit
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/lt_LT/content/reference/cli.md
+++ b/locale/lt_LT/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/lt_LT/content/reference/cli.md
+++ b/locale/lt_LT/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/lt_LT/content/reference/cli.md
+++ b/locale/lt_LT/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/lt_LT/content/running_bookwyrm/cli.md
+++ b/locale/lt_LT/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/lt_LT/content/running_bookwyrm/cli.md
+++ b/locale/lt_LT/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/lt_LT/content/running_bookwyrm/cli.md
+++ b/locale/lt_LT/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/nl_NL/content/running_bookwyrm/cli.md
+++ b/locale/nl_NL/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/nl_NL/content/running_bookwyrm/cli.md
+++ b/locale/nl_NL/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/nl_NL/content/running_bookwyrm/cli.md
+++ b/locale/nl_NL/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/no_NO/content/contributing/contributing.md
+++ b/locale/no_NO/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Kodebidrag er gjerne velkommen! Om du ikke er sikker på hvord du skal begynne, 
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/no_NO/content/reference/cli.md
+++ b/locale/no_NO/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/no_NO/content/reference/cli.md
+++ b/locale/no_NO/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/no_NO/content/reference/cli.md
+++ b/locale/no_NO/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/no_NO/content/running_bookwyrm/cli.md
+++ b/locale/no_NO/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/no_NO/content/running_bookwyrm/cli.md
+++ b/locale/no_NO/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/no_NO/content/running_bookwyrm/cli.md
+++ b/locale/no_NO/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/pl_PL/content/contributing/contributing.md
+++ b/locale/pl_PL/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Zachęcamy do udziału w pracach na kodem! Jeśli nie masz pewności, gdzie zacz
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/pl_PL/content/reference/cli.md
+++ b/locale/pl_PL/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/pl_PL/content/reference/cli.md
+++ b/locale/pl_PL/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/pl_PL/content/reference/cli.md
+++ b/locale/pl_PL/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/pl_PL/content/running_bookwyrm/cli.md
+++ b/locale/pl_PL/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/pl_PL/content/running_bookwyrm/cli.md
+++ b/locale/pl_PL/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Programiści BookWyrm oraz menedżerowie instancji mogą skorzystać ze skryptu `bw-dev` do częstych zadań. Może to skrócić Twoje polecenia, ułatwić ich zapamiętanie i utrudnić zepsucie czegoś.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Skróty Docker
 

--- a/locale/pl_PL/content/running_bookwyrm/cli.md
+++ b/locale/pl_PL/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/pt_BR/content/contributing/contributing.md
+++ b/locale/pt_BR/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Contribuições de código são muito bem-vindas! Se você não sabe por onde co
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/pt_BR/content/reference/cli.md
+++ b/locale/pt_BR/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/pt_BR/content/reference/cli.md
+++ b/locale/pt_BR/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/pt_BR/content/reference/cli.md
+++ b/locale/pt_BR/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/pt_BR/content/running_bookwyrm/cli.md
+++ b/locale/pt_BR/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/pt_BR/content/running_bookwyrm/cli.md
+++ b/locale/pt_BR/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/pt_PT/content/contributing/contributing.md
+++ b/locale/pt_PT/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Code contributions are gladly welcomed! If you're not sure where to start, take 
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/pt_PT/content/reference/cli.md
+++ b/locale/pt_PT/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/pt_PT/content/reference/cli.md
+++ b/locale/pt_PT/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/pt_PT/content/reference/cli.md
+++ b/locale/pt_PT/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/pt_PT/content/running_bookwyrm/cli.md
+++ b/locale/pt_PT/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/pt_PT/content/running_bookwyrm/cli.md
+++ b/locale/pt_PT/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/pt_PT/content/running_bookwyrm/cli.md
+++ b/locale/pt_PT/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/ro_RO/content/contributing/contributing.md
+++ b/locale/ro_RO/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Contribuțiile la cod sunt mai mult ca binevenite! Dacă nu știți de unde să 
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/ro_RO/content/reference/cli.md
+++ b/locale/ro_RO/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/ro_RO/content/reference/cli.md
+++ b/locale/ro_RO/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/ro_RO/content/reference/cli.md
+++ b/locale/ro_RO/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/ro_RO/content/running_bookwyrm/cli.md
+++ b/locale/ro_RO/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/ro_RO/content/running_bookwyrm/cli.md
+++ b/locale/ro_RO/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/ru_RU/content/running_bookwyrm/cli.md
+++ b/locale/ru_RU/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/ru_RU/content/running_bookwyrm/cli.md
+++ b/locale/ru_RU/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/ru_RU/content/running_bookwyrm/cli.md
+++ b/locale/ru_RU/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/sl_SI/content/running_bookwyrm/cli.md
+++ b/locale/sl_SI/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/sl_SI/content/running_bookwyrm/cli.md
+++ b/locale/sl_SI/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/sl_SI/content/running_bookwyrm/cli.md
+++ b/locale/sl_SI/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/sr_SP/content/running_bookwyrm/cli.md
+++ b/locale/sr_SP/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/sr_SP/content/running_bookwyrm/cli.md
+++ b/locale/sr_SP/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/sr_SP/content/running_bookwyrm/cli.md
+++ b/locale/sr_SP/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/sv_SE/content/contributing/contributing.md
+++ b/locale/sv_SE/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Code contributions are gladly welcomed! If you're not sure where to start, take 
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/sv_SE/content/reference/cli.md
+++ b/locale/sv_SE/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/sv_SE/content/reference/cli.md
+++ b/locale/sv_SE/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/sv_SE/content/reference/cli.md
+++ b/locale/sv_SE/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/sv_SE/content/running_bookwyrm/cli.md
+++ b/locale/sv_SE/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/sv_SE/content/running_bookwyrm/cli.md
+++ b/locale/sv_SE/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/sv_SE/content/running_bookwyrm/cli.md
+++ b/locale/sv_SE/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/tr_TR/content/running_bookwyrm/cli.md
+++ b/locale/tr_TR/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/tr_TR/content/running_bookwyrm/cli.md
+++ b/locale/tr_TR/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/tr_TR/content/running_bookwyrm/cli.md
+++ b/locale/tr_TR/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/uk_UA/content/running_bookwyrm/cli.md
+++ b/locale/uk_UA/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/uk_UA/content/running_bookwyrm/cli.md
+++ b/locale/uk_UA/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/uk_UA/content/running_bookwyrm/cli.md
+++ b/locale/uk_UA/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Розробники і менеджери bookwyrm можуть використовувати скрипт `bw-dev` для загальних завдань. Це може зробити команди коротшими, зручнішими до запам'ятання, і складніше робити помилки.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/vi_VN/content/running_bookwyrm/cli.md
+++ b/locale/vi_VN/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/vi_VN/content/running_bookwyrm/cli.md
+++ b/locale/vi_VN/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/vi_VN/content/running_bookwyrm/cli.md
+++ b/locale/vi_VN/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/zh_Hans/content/contributing/contributing.md
+++ b/locale/zh_Hans/content/contributing/contributing.md
@@ -54,7 +54,7 @@ Code contributions are gladly welcomed! If you're not sure where to start, take 
 Check out the [Guide to the developer environment](https://docs.joinbookwyrm.com/install-dev.html) and our code [style guide](https://docs.joinbookwyrm.com/style_guide.html).
 
 ### Create and update documentation
-Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/contributing/documentation.html).
+Good documentation is crucial so that people know how to use, contribute to, and administer BookWyrm. No matter how you are involved with BookWyrm, your perspective is valuable and you can contribute to our documentation. Find out more about [how you can contribute to the docs](/documentation.html).
 
 ### Translate BookWyrm
 Books are written in many languages, and BookWyrm should be too. If you know more than one language, you might be able to help us to [translate BookWyrm](https://translate.joinbookwyrm.com/). Find out [more about translation](/translation.html).

--- a/locale/zh_Hans/content/reference/cli.md
+++ b/locale/zh_Hans/content/reference/cli.md
@@ -215,7 +215,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### set_cors_to_s3 filename
 

--- a/locale/zh_Hans/content/reference/cli.md
+++ b/locale/zh_Hans/content/reference/cli.md
@@ -6,7 +6,7 @@ Order: 2
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 Some commands only run in development environments, most can be run in either development or production, and a small number should only be run in production. Development commands run in a dedicated Docker environment configured in `docker-compose.dev.yml`, whereas production commands run in the production environment configured in `docker-compose.yml`. Production containers and volumes have names starting with `bookwyrm`, and development containers and volumes start with `dev-wyrm`
 

--- a/locale/zh_Hans/content/reference/cli.md
+++ b/locale/zh_Hans/content/reference/cli.md
@@ -76,7 +76,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 #### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelint` before committing changes to scripts to automatically format your code.
 
 #### formatters
 

--- a/locale/zh_Hans/content/running_bookwyrm/cli.md
+++ b/locale/zh_Hans/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/zh_Hans/content/running_bookwyrm/cli.md
+++ b/locale/zh_Hans/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/zh_Hans/content/running_bookwyrm/cli.md
+++ b/locale/zh_Hans/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/locale/zh_Hant/content/running_bookwyrm/cli.md
+++ b/locale/zh_Hant/content/running_bookwyrm/cli.md
@@ -78,7 +78,7 @@ Generate preview images for site, users, and books. This can take a while if you
 
 ### remove_remote_user_preview_images
 
-Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html)
+Remove generated preview images for remote users. See [Optional Features: Removing preview images for remote users](/optional_features.html#removing-preview-images-for-remote-users)
 
 ### generate_thumbnails
 

--- a/locale/zh_Hant/content/running_bookwyrm/cli.md
+++ b/locale/zh_Hant/content/running_bookwyrm/cli.md
@@ -142,7 +142,7 @@ BookWyrm uses [Prettier](https://prettier.io/) to keep the JavaScript codebase c
 
 ### stylelint
 
-BookWyrm uses [Stylelint](uhttps://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
+BookWyrm uses [Stylelint](https://stylelint.io/) to keep the CSS files consistently styled. Run `stylelintprettier` before committing changes to scripts to automatically format your code.
 
 ### formatters
 

--- a/locale/zh_Hant/content/running_bookwyrm/cli.md
+++ b/locale/zh_Hant/content/running_bookwyrm/cli.md
@@ -4,7 +4,7 @@ Title: Command Line Tool Date: 2021-11-11 Order: 9
 
 Bookwyrm developers and instance managers can use the `bw-dev` script for common tasks. This can make your commands shorter, easier to remember, and harder to mess up.
 
-Once you have installed Bookwyrm [in production](installing-in-production.html) or [in development](https://docs.joinbookwyrm.com/developer-environment.html#setting_up_the_developer_environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
+Once you have installed Bookwyrm [in production](install-prod.html) or [in development](https://docs.joinbookwyrm.com/install-dev.html#setting-up-the-developer-environment), you can run the script from the command line with `./bw-dev` followed by the subcommand you want to run.
 
 ## Docker shortcuts
 

--- a/site/cli.html
+++ b/site/cli.html
@@ -448,7 +448,7 @@ Command Line Tool
 <h4 id="prettier"><a class="headerlink" href="#prettier">prettier</a></h4>
 <p>BookWyrm uses <a href="https://prettier.io/">Prettier</a> to keep the JavaScript codebase consistently styled. Run <code>prettier</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="stylelint"><a class="headerlink" href="#stylelint">stylelint</a></h4>
-<p>BookWyrm uses <a href="uhttps://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
+<p>BookWyrm uses <a href="https://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="formatters"><a class="headerlink" href="#formatters">formatters</a></h4>
 <p>This command runs all code formatters (<code>ruff format</code>, <code>ruff check</code>, <code>prettier</code>,<code>eslint</code>  and <code>stylelint</code>) in one go.</p>
 <h2 id="dangerous-development-commands"><a class="headerlink" href="#dangerous-development-commands">Dangerous development commands</a></h2>

--- a/site/de/cli.html
+++ b/site/de/cli.html
@@ -456,7 +456,7 @@ Command Line Tool
 <h4 id="prettier"><a class="headerlink" href="#prettier">prettier</a></h4>
 <p>BookWyrm uses <a href="https://prettier.io/">Prettier</a> to keep the JavaScript codebase consistently styled. Run <code>prettier</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="stylelint"><a class="headerlink" href="#stylelint">stylelint</a></h4>
-<p>BookWyrm uses <a href="uhttps://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
+<p>BookWyrm uses <a href="https://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="formatters"><a class="headerlink" href="#formatters">formatters</a></h4>
 <p>This command runs all code formatters (<code>ruff format</code>, <code>ruff check</code>, <code>prettier</code>,<code>eslint</code>  and <code>stylelint</code>) in one go.</p>
 <h2 id="dangerous-development-commands"><a class="headerlink" href="#dangerous-development-commands">Dangerous development commands</a></h2>

--- a/site/fr/cli.html
+++ b/site/fr/cli.html
@@ -456,7 +456,7 @@ Command Line Tool
 <h4 id="prettier"><a class="headerlink" href="#prettier">prettier</a></h4>
 <p>BookWyrm uses <a href="https://prettier.io/">Prettier</a> to keep the JavaScript codebase consistently styled. Run <code>prettier</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="stylelint"><a class="headerlink" href="#stylelint">stylelint</a></h4>
-<p>BookWyrm uses <a href="uhttps://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
+<p>BookWyrm uses <a href="https://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="formatters"><a class="headerlink" href="#formatters">formatters</a></h4>
 <p>This command runs all code formatters (<code>ruff format</code>, <code>ruff check</code>, <code>prettier</code>,<code>eslint</code>  and <code>stylelint</code>) in one go.</p>
 <h2 id="dangerous-development-commands"><a class="headerlink" href="#dangerous-development-commands">Dangerous development commands</a></h2>

--- a/site/pl/cli.html
+++ b/site/pl/cli.html
@@ -456,7 +456,7 @@ Command Line Tool
 <h4 id="prettier"><a class="headerlink" href="#prettier">prettier</a></h4>
 <p>BookWyrm uses <a href="https://prettier.io/">Prettier</a> to keep the JavaScript codebase consistently styled. Run <code>prettier</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="stylelint"><a class="headerlink" href="#stylelint">stylelint</a></h4>
-<p>BookWyrm uses <a href="uhttps://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
+<p>BookWyrm uses <a href="https://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="formatters"><a class="headerlink" href="#formatters">formatters</a></h4>
 <p>This command runs all code formatters (<code>ruff format</code>, <code>ruff check</code>, <code>prettier</code>,<code>eslint</code>  and <code>stylelint</code>) in one go.</p>
 <h2 id="dangerous-development-commands"><a class="headerlink" href="#dangerous-development-commands">Dangerous development commands</a></h2>

--- a/site/pt-br/cli.html
+++ b/site/pt-br/cli.html
@@ -456,7 +456,7 @@ Command Line Tool
 <h4 id="prettier"><a class="headerlink" href="#prettier">prettier</a></h4>
 <p>BookWyrm uses <a href="https://prettier.io/">Prettier</a> to keep the JavaScript codebase consistently styled. Run <code>prettier</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="stylelint"><a class="headerlink" href="#stylelint">stylelint</a></h4>
-<p>BookWyrm uses <a href="uhttps://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
+<p>BookWyrm uses <a href="https://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="formatters"><a class="headerlink" href="#formatters">formatters</a></h4>
 <p>This command runs all code formatters (<code>ruff format</code>, <code>ruff check</code>, <code>prettier</code>,<code>eslint</code>  and <code>stylelint</code>) in one go.</p>
 <h2 id="dangerous-development-commands"><a class="headerlink" href="#dangerous-development-commands">Dangerous development commands</a></h2>

--- a/site/ro/cli.html
+++ b/site/ro/cli.html
@@ -456,7 +456,7 @@ Command Line Tool
 <h4 id="prettier"><a class="headerlink" href="#prettier">prettier</a></h4>
 <p>BookWyrm uses <a href="https://prettier.io/">Prettier</a> to keep the JavaScript codebase consistently styled. Run <code>prettier</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="stylelint"><a class="headerlink" href="#stylelint">stylelint</a></h4>
-<p>BookWyrm uses <a href="uhttps://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
+<p>BookWyrm uses <a href="https://stylelint.io/">Stylelint</a> to keep the CSS files consistently styled. Run <code>stylelint</code> before committing changes to scripts to automatically format your code.</p>
 <h4 id="formatters"><a class="headerlink" href="#formatters">formatters</a></h4>
 <p>This command runs all code formatters (<code>ruff format</code>, <code>ruff check</code>, <code>prettier</code>,<code>eslint</code>  and <code>stylelint</code>) in one go.</p>
 <h2 id="dangerous-development-commands"><a class="headerlink" href="#dangerous-development-commands">Dangerous development commands</a></h2>


### PR DESCRIPTION
going through the documentation fixing or improving five sets of links

`/contributing/documentation.html` => `/documentation.html`
`installing-in-production.html` => `install-prod.html`
`developer-environment.html#setting_up_the_developer_environment` => `install-dev.html#setting-up-the-developer-environment`
`uhttps://stylelint.io/` => `https://stylelint.io/`
and
adding `#removing-preview-images-for-remote-users` anchor for optional features.

these were all the links that I could find from a cursory search that were just outright broken